### PR TITLE
feat: implement snake chain rule

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,7 @@ import {
 } from './lib/localStorage'
 
 import { CONFIG } from './constants/config'
+import { getChainInfo } from './lib/chain'
 import ReactGA from 'react-ga'
 import '@bcgov/bc-sans/css/BCSans.css'
 import './i18n'
@@ -82,8 +83,10 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
   }, [isGameWon, isGameLost, t])
 
   const onChar = (value: string) => {
+    const chainInfo = getChainInfo(guesses)
+    const maxLength = chainInfo ? CONFIG.wordLength - 1 : CONFIG.wordLength
     if (
-      currentGuess.length < CONFIG.wordLength &&
+      currentGuess.length < maxLength &&
       guesses.length < CONFIG.tries &&
       !isGameWon
     ) {
@@ -100,28 +103,32 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
     if (isGameWon || isGameLost) {
       return
     }
-    if (!(currentGuess.length === CONFIG.wordLength)) {
+
+    const chainInfo = getChainInfo(guesses)
+    const fullGuess = chainInfo
+      ? chainInfo.position === 'first'
+        ? [chainInfo.letter, ...currentGuess]
+        : [...currentGuess, chainInfo.letter]
+      : currentGuess
+
+    if (fullGuess.length !== CONFIG.wordLength) {
       setIsNotEnoughLetters(true)
       return setTimeout(() => {
         setIsNotEnoughLetters(false)
       }, ALERT_TIME_MS)
     }
 
-    if (!isWordInWordList(currentGuess.join(''))) {
+    if (!isWordInWordList(fullGuess.join(''))) {
       setIsWordNotFoundAlertOpen(true)
       return setTimeout(() => {
         setIsWordNotFoundAlertOpen(false)
       }, ALERT_TIME_MS)
     }
-    const winningWord = isWinningWord(currentGuess.join(''))
+    const winningWord = isWinningWord(fullGuess.join(''))
 
-    if (
-      currentGuess.length === CONFIG.wordLength &&
-      guesses.length < CONFIG.tries &&
-      !isGameWon
-    ) {
-      setGuesses([...guesses, currentGuess])
+    if (guesses.length < CONFIG.tries && !isGameWon) {
       setCurrentGuess([])
+      setGuesses([...guesses, fullGuess])
 
       if (winningWord) {
         setStats(addStatsForCompletedGame(stats, guesses.length))

--- a/src/components/grid/Cell.tsx
+++ b/src/components/grid/Cell.tsx
@@ -4,14 +4,16 @@ import classnames from 'classnames'
 type Props = {
   value?: string
   status?: CharStatus
+  isLocked?: boolean
 }
 
-export const Cell = ({ value, status }: Props) => {
+export const Cell = ({ value, status, isLocked }: Props) => {
   const classes = classnames(
     'w-14 h-14 border-solid border-2 flex items-center justify-center mx-0.5 text-lg font-bold rounded',
     {
-      'bg-white border-slate-200': !status,
-      'border-black': value && !status,
+      'bg-white border-slate-200': !status && !isLocked,
+      'border-black': value && !status && !isLocked,
+      'bg-slate-100 border-slate-400': isLocked && !status,
       'bg-slate-400 text-white border-slate-400': status === 'absent',
       'bg-green-500 text-white border-green-500': status === 'correct',
       'bg-purple-500 text-white border-purple-500': status === 'present',

--- a/src/components/grid/CurrentRow.tsx
+++ b/src/components/grid/CurrentRow.tsx
@@ -1,22 +1,61 @@
 import { Cell } from './Cell'
 import { CONFIG } from '../../constants/config'
+import { getChainInfo } from '../../lib/chain'
 
 type Props = {
   guess: string[]
+  guesses: string[][]
 }
 
-export const CurrentRow = ({ guess }: Props) => {
-  const splitGuess = guess
-  const emptyCells = Array.from(Array(CONFIG.wordLength - splitGuess.length))
+export const CurrentRow = ({ guess, guesses }: Props) => {
+  const chainInfo = getChainInfo(guesses)
 
+  if (!chainInfo) {
+    // First guess: no chain
+    const emptyCells = Array.from(Array(CONFIG.wordLength - guess.length))
+    return (
+      <div className="flex justify-center mb-1">
+        {guess.map((letter, i) => (
+          <Cell key={i} value={letter} />
+        ))}
+        {emptyCells.map((_, i) => (
+          <Cell key={guess.length + i} />
+        ))}
+      </div>
+    )
+  }
+
+  if (chainInfo.position === 'first') {
+    // Left chain: [locked] [typed...] [empties...]
+    const emptyCells = Array.from(
+      Array(Math.max(0, CONFIG.wordLength - 1 - guess.length))
+    )
+    return (
+      <div className="flex justify-center mb-1">
+        <Cell value={chainInfo.letter} isLocked />
+        {guess.map((letter, i) => (
+          <Cell key={i} value={letter} />
+        ))}
+        {emptyCells.map((_, i) => (
+          <Cell key={guess.length + i} />
+        ))}
+      </div>
+    )
+  }
+
+  // Right chain: [typed...] [empties...] [locked]
+  const emptyCells = Array.from(
+    Array(Math.max(0, CONFIG.wordLength - 1 - guess.length))
+  )
   return (
     <div className="flex justify-center mb-1">
-      {splitGuess.map((letter, i) => (
+      {guess.map((letter, i) => (
         <Cell key={i} value={letter} />
       ))}
       {emptyCells.map((_, i) => (
-        <Cell key={i} />
+        <Cell key={guess.length + i} />
       ))}
+      <Cell value={chainInfo.letter} isLocked />
     </div>
   )
 }

--- a/src/components/grid/Grid.tsx
+++ b/src/components/grid/Grid.tsx
@@ -19,7 +19,9 @@ export const Grid = ({ guesses, currentGuess }: Props) => {
       {guesses.map((guess, i) => (
         <CompletedRow key={i} guess={guess} />
       ))}
-      {guesses.length < CONFIG.tries && <CurrentRow guess={currentGuess} />}
+      {guesses.length < CONFIG.tries && (
+        <CurrentRow guess={currentGuess} guesses={guesses} />
+      )}
       {empties.map((_, i) => (
         <EmptyRow key={i} />
       ))}

--- a/src/lib/chain.ts
+++ b/src/lib/chain.ts
@@ -1,0 +1,13 @@
+export type ChainInfo = { letter: string; position: 'first' | 'last' }
+
+export function getChainInfo(guesses: string[][]): ChainInfo | null {
+  if (guesses.length === 0) return null
+  const prev = guesses[guesses.length - 1]
+  if (guesses.length % 2 === 1) {
+    // 1→2, 3→4, 5→6: 끝 글자 체인 (오른쪽)
+    return { letter: prev[prev.length - 1], position: 'last' }
+  } else {
+    // 2→3, 4→5: 첫 글자 체인 (왼쪽)
+    return { letter: prev[0], position: 'first' }
+  }
+}


### PR DESCRIPTION
## Summary
- Snake chain rule: 2번째 추측부터 이전 추측과 글자 체인 (좌우 교대, 뱀 모양)
- 체인 글자 자동 채움 + 삭제 불가 (locked cell)
- React 17 unbatched state update 문제 해결 (setCurrentGuess → setGuesses 순서)

## Changed files
- `src/lib/chain.ts` (new) — `getChainInfo()` helper
- `src/App.tsx` — onChar/onEnter chain logic
- `src/components/grid/Grid.tsx` — pass guesses to CurrentRow
- `src/components/grid/CurrentRow.tsx` — chain-aware rendering
- `src/components/grid/Cell.tsx` — isLocked prop + style

## Test plan
- [x] 첫 단어 입력 → Enter → 다음 행에 chain 글자 자동 채움 확인
- [x] chain 글자 삭제 불가 확인
- [x] 4글자 타이핑 후 Enter → 정상 동작 확인
- [x] 단어 목록에 없는 조합 → "Word not found" 확인
- [x] `npm test` 통과
- [x] `npm run build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)