### PR TITLE
feat: add visual chain connector UI

### DIFF
--- a/src/components/grid/Cell.tsx
+++ b/src/components/grid/Cell.tsx
@@ -5,18 +5,38 @@ type Props = {
   value?: string
   status?: CharStatus
   isLocked?: boolean
+  chainTop?: boolean
+  chainBottom?: boolean
 }
 
-export const Cell = ({ value, status, isLocked }: Props) => {
+export const Cell = ({
+  value,
+  status,
+  isLocked,
+  chainTop,
+  chainBottom,
+}: Props) => {
+  const isChain = chainTop || chainBottom
+
   const classes = classnames(
     'w-14 h-14 border-solid border-2 flex items-center justify-center mx-0.5 text-lg font-bold rounded',
     {
-      'bg-white border-slate-200': !status && !isLocked,
-      'border-black': value && !status && !isLocked,
-      'bg-slate-100 border-slate-400': isLocked && !status,
-      'bg-slate-400 text-white border-slate-400': status === 'absent',
-      'bg-green-500 text-white border-green-500': status === 'correct',
-      'bg-purple-500 text-white border-purple-500': status === 'present',
+      'bg-white border-slate-200': !status && !isLocked && !isChain,
+      'border-black': value && !status && !isLocked && !isChain,
+      'bg-white border-black': isChain && !status && !isLocked,
+      'bg-slate-100 border-black': isLocked && !status,
+      'bg-slate-400 text-white border-slate-400': status === 'absent' && !isChain,
+      'bg-slate-400 text-white border-black': status === 'absent' && isChain,
+      'bg-green-500 text-white border-green-500':
+        status === 'correct' && !isChain,
+      'bg-purple-500 text-white border-purple-500':
+        status === 'present' && !isChain,
+      'bg-green-500 text-white border-black':
+        status === 'correct' && isChain,
+      'bg-purple-500 text-white border-black':
+        status === 'present' && isChain,
+      'border-b-0 rounded-b-none': chainBottom,
+      'border-t-0 rounded-t-none': chainTop,
       'cell-animation': !!value,
     }
   )

--- a/src/components/grid/ChainBridge.tsx
+++ b/src/components/grid/ChainBridge.tsx
@@ -1,0 +1,23 @@
+import { CONFIG } from '../../constants/config'
+import classnames from 'classnames'
+
+type Props = {
+  chainIndex: number
+}
+
+export const ChainBridge = ({ chainIndex }: Props) => {
+  const cells = Array.from(Array(CONFIG.wordLength))
+
+  return (
+    <div className="flex justify-center -mt-1">
+      {cells.map((_, i) => (
+        <div
+          key={i}
+          className={classnames('w-14 h-1 mx-0.5', {
+            'border-l-2 border-r-2 border-black': i === chainIndex,
+          })}
+        />
+      ))}
+    </div>
+  )
+}

--- a/src/components/grid/CompletedRow.tsx
+++ b/src/components/grid/CompletedRow.tsx
@@ -3,15 +3,27 @@ import { Cell } from './Cell'
 
 type Props = {
   guess: string[]
+  chainTopIndex?: number
+  chainBottomIndex?: number
 }
 
-export const CompletedRow = ({ guess }: Props) => {
+export const CompletedRow = ({
+  guess,
+  chainTopIndex,
+  chainBottomIndex,
+}: Props) => {
   const statuses = getGuessStatuses(guess)
 
   return (
     <div className="flex justify-center mb-1">
       {guess.map((letter, i) => (
-        <Cell key={i} value={letter} status={statuses[i]} />
+        <Cell
+          key={i}
+          value={letter}
+          status={statuses[i]}
+          chainTop={i === chainTopIndex}
+          chainBottom={i === chainBottomIndex}
+        />
       ))}
     </div>
   )

--- a/src/components/grid/CurrentRow.tsx
+++ b/src/components/grid/CurrentRow.tsx
@@ -5,57 +5,48 @@ import { getChainInfo } from '../../lib/chain'
 type Props = {
   guess: string[]
   guesses: string[][]
+  chainTopIndex?: number
+  chainBottomIndex?: number
 }
 
-export const CurrentRow = ({ guess, guesses }: Props) => {
+export const CurrentRow = ({
+  guess,
+  guesses,
+  chainTopIndex,
+  chainBottomIndex,
+}: Props) => {
   const chainInfo = getChainInfo(guesses)
 
+  // Build full row of cells with column indices
+  const cells: { value?: string; isLocked?: boolean }[] = []
+
   if (!chainInfo) {
-    // First guess: no chain
-    const emptyCells = Array.from(Array(CONFIG.wordLength - guess.length))
-    return (
-      <div className="flex justify-center mb-1">
-        {guess.map((letter, i) => (
-          <Cell key={i} value={letter} />
-        ))}
-        {emptyCells.map((_, i) => (
-          <Cell key={guess.length + i} />
-        ))}
-      </div>
-    )
+    for (let i = 0; i < CONFIG.wordLength; i++) {
+      cells.push({ value: guess[i] })
+    }
+  } else if (chainInfo.position === 'first') {
+    cells.push({ value: chainInfo.letter, isLocked: true })
+    for (let i = 0; i < CONFIG.wordLength - 1; i++) {
+      cells.push({ value: guess[i] })
+    }
+  } else {
+    for (let i = 0; i < CONFIG.wordLength - 1; i++) {
+      cells.push({ value: guess[i] })
+    }
+    cells.push({ value: chainInfo.letter, isLocked: true })
   }
 
-  if (chainInfo.position === 'first') {
-    // Left chain: [locked] [typed...] [empties...]
-    const emptyCells = Array.from(
-      Array(Math.max(0, CONFIG.wordLength - 1 - guess.length))
-    )
-    return (
-      <div className="flex justify-center mb-1">
-        <Cell value={chainInfo.letter} isLocked />
-        {guess.map((letter, i) => (
-          <Cell key={i} value={letter} />
-        ))}
-        {emptyCells.map((_, i) => (
-          <Cell key={guess.length + i} />
-        ))}
-      </div>
-    )
-  }
-
-  // Right chain: [typed...] [empties...] [locked]
-  const emptyCells = Array.from(
-    Array(Math.max(0, CONFIG.wordLength - 1 - guess.length))
-  )
   return (
     <div className="flex justify-center mb-1">
-      {guess.map((letter, i) => (
-        <Cell key={i} value={letter} />
+      {cells.map((cell, i) => (
+        <Cell
+          key={i}
+          value={cell.value}
+          isLocked={cell.isLocked}
+          chainTop={i === chainTopIndex}
+          chainBottom={i === chainBottomIndex}
+        />
       ))}
-      {emptyCells.map((_, i) => (
-        <Cell key={guess.length + i} />
-      ))}
-      <Cell value={chainInfo.letter} isLocked />
     </div>
   )
 }

--- a/src/components/grid/EmptyRow.tsx
+++ b/src/components/grid/EmptyRow.tsx
@@ -1,13 +1,22 @@
 import { Cell } from './Cell'
 import { CONFIG } from '../../constants/config'
 
-export const EmptyRow = () => {
+type Props = {
+  chainTopIndex?: number
+  chainBottomIndex?: number
+}
+
+export const EmptyRow = ({ chainTopIndex, chainBottomIndex }: Props) => {
   const emptyCells = Array.from(Array(CONFIG.wordLength))
 
   return (
     <div className="flex justify-center mb-1">
       {emptyCells.map((_, i) => (
-        <Cell key={i} />
+        <Cell
+          key={i}
+          chainTop={i === chainTopIndex}
+          chainBottom={i === chainBottomIndex}
+        />
       ))}
     </div>
   )

--- a/src/components/grid/Grid.tsx
+++ b/src/components/grid/Grid.tsx
@@ -1,30 +1,79 @@
 import { CompletedRow } from './CompletedRow'
 import { CurrentRow } from './CurrentRow'
 import { EmptyRow } from './EmptyRow'
+import { ChainBridge } from './ChainBridge'
 import { CONFIG } from '../../constants/config'
+import React from 'react'
 
 type Props = {
   guesses: string[][]
   currentGuess: string[]
 }
 
-export const Grid = ({ guesses, currentGuess }: Props) => {
-  const empties =
-    guesses.length < CONFIG.tries - 1
-      ? Array.from(Array(CONFIG.tries - 1 - guesses.length))
-      : []
+function getChainPositions(rowIndex: number) {
+  const chainTopIndex =
+    rowIndex > 0
+      ? (rowIndex - 1) % 2 === 0
+        ? CONFIG.wordLength - 1
+        : 0
+      : undefined
+  const chainBottomIndex =
+    rowIndex < CONFIG.tries - 1
+      ? rowIndex % 2 === 0
+        ? CONFIG.wordLength - 1
+        : 0
+      : undefined
+  return { chainTopIndex, chainBottomIndex }
+}
 
-  return (
-    <div className="pb-6">
-      {guesses.map((guess, i) => (
-        <CompletedRow key={i} guess={guess} />
-      ))}
-      {guesses.length < CONFIG.tries && (
-        <CurrentRow guess={currentGuess} guesses={guesses} />
-      )}
-      {empties.map((_, i) => (
-        <EmptyRow key={i} />
-      ))}
-    </div>
-  )
+function getBridgeChainIndex(rowIndex: number) {
+  return rowIndex % 2 === 0 ? CONFIG.wordLength - 1 : 0
+}
+
+export const Grid = ({ guesses, currentGuess }: Props) => {
+  const elements: React.ReactNode[] = []
+
+  for (let i = 0; i < CONFIG.tries; i++) {
+    const { chainTopIndex, chainBottomIndex } = getChainPositions(i)
+
+    if (i < guesses.length) {
+      elements.push(
+        <CompletedRow
+          key={`row-${i}`}
+          guess={guesses[i]}
+          chainTopIndex={chainTopIndex}
+          chainBottomIndex={chainBottomIndex}
+        />
+      )
+    } else if (i === guesses.length) {
+      elements.push(
+        <CurrentRow
+          key={`row-${i}`}
+          guess={currentGuess}
+          guesses={guesses}
+          chainTopIndex={chainTopIndex}
+          chainBottomIndex={chainBottomIndex}
+        />
+      )
+    } else {
+      elements.push(
+        <EmptyRow
+          key={`row-${i}`}
+          chainTopIndex={chainTopIndex}
+          chainBottomIndex={chainBottomIndex}
+        />
+      )
+    }
+
+    if (i < CONFIG.tries - 1) {
+      elements.push(
+        <ChainBridge
+          key={`bridge-${i}`}
+          chainIndex={getBridgeChainIndex(i)}
+        />
+      )
+    }
+  }
+
+  return <div className="pb-6">{elements}</div>
 }


### PR DESCRIPTION
## Summary
- 체인으로 연결된 셀들을 하나의 둥근 사각형으로 시각적으로 묶음
- ChainBridge 컴포넌트로 행 사이 갭에 좌우 테두리 연결
- 체인 셀은 `border-black`으로 뱀 패턴이 명확히 보임

## Changed files
- `src/components/grid/ChainBridge.tsx` (new) — 행 간 체인 연결 브릿지
- `src/components/grid/Cell.tsx` — chainTop/chainBottom props, 체인 테두리 스타일
- `src/components/grid/Grid.tsx` — 체인 위치 계산, 브릿지 삽입
- `src/components/grid/CompletedRow.tsx` — 체인 props 전달
- `src/components/grid/CurrentRow.tsx` — 체인 props 전달, 셀 배열 방식으로 리팩터
- `src/components/grid/EmptyRow.tsx` — 체인 props 전달

## Test plan
- [x] 초기 화면에서 뱀 모양 체인 커넥터 표시 확인
- [x] `npm test` 통과
- [x] `npm run build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)