### PR TITLE
feat: detect chain dead end and trigger early game loss

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,7 +17,8 @@ import {
 } from './lib/localStorage'
 
 import { CONFIG } from './constants/config'
-import { getChainInfo } from './lib/chain'
+import { getChainInfo, isChainDeadEnd } from './lib/chain'
+import { ORTHOGRAPHY_PATTERN } from './lib/tokenizer'
 import ReactGA from 'react-ga'
 import '@bcgov/bc-sans/css/BCSans.css'
 import './i18n'
@@ -49,6 +50,12 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
     }
     if (loaded.guesses.length === CONFIG.tries && !gameWasWon) {
       setIsGameLost(true)
+    }
+    if (!gameWasWon && loaded.guesses.length === CONFIG.tries - 1) {
+      const solutionChars = solution.split(ORTHOGRAPHY_PATTERN).filter((i) => i)
+      if (isChainDeadEnd(loaded.guesses, solutionChars)) {
+        setIsGameLost(true)
+      }
     }
     return loaded.guesses
   })
@@ -133,6 +140,18 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
       if (winningWord) {
         setStats(addStatsForCompletedGame(stats, guesses.length))
         return setIsGameWon(true)
+      }
+
+      if (guesses.length === CONFIG.tries - 2) {
+        const newGuesses = [...guesses, fullGuess]
+        const solutionChars = solution
+          .split(ORTHOGRAPHY_PATTERN)
+          .filter((i) => i)
+        if (isChainDeadEnd(newGuesses, solutionChars)) {
+          setStats(addStatsForCompletedGame(stats, CONFIG.tries))
+          setIsGameLost(true)
+          return
+        }
       }
 
       if (guesses.length === CONFIG.tries - 1) {

--- a/src/lib/chain.ts
+++ b/src/lib/chain.ts
@@ -1,3 +1,5 @@
+import { CONFIG } from '../constants/config'
+
 export type ChainInfo = { letter: string; position: 'first' | 'last' }
 
 export function getChainInfo(guesses: string[][]): ChainInfo | null {
@@ -10,4 +12,15 @@ export function getChainInfo(guesses: string[][]): ChainInfo | null {
     // 2→3, 4→5: 첫 글자 체인 (왼쪽)
     return { letter: prev[0], position: 'first' }
   }
+}
+
+export function isChainDeadEnd(
+  guesses: string[][],
+  solutionChars: string[]
+): boolean {
+  const chainInfo = getChainInfo(guesses)
+  if (!chainInfo) return false
+  const chainPos =
+    chainInfo.position === 'first' ? 0 : CONFIG.wordLength - 1
+  return solutionChars[chainPos] !== chainInfo.letter
 }


### PR DESCRIPTION
## Summary
- 마지막 전 추측(5번째) 입력 시 다음 추측의 체인 글자가 정답과 불일치하면 즉시 실패 처리
- `isChainDeadEnd` 헬퍼 함수를 `chain.ts`에 추가
- localStorage 복원 시에도 동일한 조기 실패 감지 적용

## Test plan
- [ ] 5번째 추측의 체인 글자가 정답과 불일치 → 즉시 실패 Alert + 정답 표시
- [ ] 5번째 추측의 체인 글자가 정답과 일치 → 6번째 추측 정상 진행
- [ ] 조기 실패 후 새로고침 → 실패 상태 유지
- [ ] `npm test` 통과
- [ ] `npm run build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)