### PR TITLE
feat: show previous guess status on locked chain letter

### DIFF
--- a/src/components/grid/CurrentRow.tsx
+++ b/src/components/grid/CurrentRow.tsx
@@ -1,6 +1,7 @@
 import { Cell } from './Cell'
 import { CONFIG } from '../../constants/config'
 import { getChainInfo } from '../../lib/chain'
+import { CharStatus, getGuessStatuses } from '../../lib/statuses'
 
 type Props = {
   guess: string[]
@@ -17,15 +18,25 @@ export const CurrentRow = ({
 }: Props) => {
   const chainInfo = getChainInfo(guesses)
 
+  let chainStatus: CharStatus | undefined
+  if (chainInfo) {
+    const prev = guesses[guesses.length - 1]
+    const prevStatuses = getGuessStatuses(prev)
+    const chainPos =
+      chainInfo.position === 'first' ? 0 : CONFIG.wordLength - 1
+    chainStatus = prevStatuses[chainPos]
+  }
+
   // Build full row of cells with column indices
-  const cells: { value?: string; isLocked?: boolean }[] = []
+  const cells: { value?: string; isLocked?: boolean; status?: CharStatus }[] =
+    []
 
   if (!chainInfo) {
     for (let i = 0; i < CONFIG.wordLength; i++) {
       cells.push({ value: guess[i] })
     }
   } else if (chainInfo.position === 'first') {
-    cells.push({ value: chainInfo.letter, isLocked: true })
+    cells.push({ value: chainInfo.letter, isLocked: true, status: chainStatus })
     for (let i = 0; i < CONFIG.wordLength - 1; i++) {
       cells.push({ value: guess[i] })
     }
@@ -33,7 +44,7 @@ export const CurrentRow = ({
     for (let i = 0; i < CONFIG.wordLength - 1; i++) {
       cells.push({ value: guess[i] })
     }
-    cells.push({ value: chainInfo.letter, isLocked: true })
+    cells.push({ value: chainInfo.letter, isLocked: true, status: chainStatus })
   }
 
   return (
@@ -42,6 +53,7 @@ export const CurrentRow = ({
         <Cell
           key={i}
           value={cell.value}
+          status={cell.status}
           isLocked={cell.isLocked}
           chainTop={i === chainTopIndex}
           chainBottom={i === chainBottomIndex}


### PR DESCRIPTION
## Summary
- CurrentRow의 locked 체인 글자에 이전 추측의 status 색상(green/purple/gray) 표시
- `getGuessStatuses`로 이전 행의 체인 위치 status를 가져와 Cell에 전달

## Test plan
- [ ] 첫 단어 입력 후 다음 행의 체인 글자에 이전 행과 동일한 색상 표시 확인
- [ ] correct(green), present(purple), absent(gray) 각각 정상 표시
- [ ] `npm test` 통과
- [ ] `npm run build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)