### PR TITLE
feat: redesign share format with snake chain visualization

### DIFF
--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,38 +1,53 @@
 import { getGuessStatuses } from './statuses'
-import { solutionIndex } from './words'
 import { CONFIG } from '../constants/config'
 
 export const shareStatus = (guesses: string[][], lost: boolean) => {
-  navigator.clipboard.writeText(
-    CONFIG.language +
-      solutionIndex +
-      ' ' +
-      `${lost ? 'X' : guesses.length}` +
-      '/' +
-      CONFIG.tries.toString() +
-      '\n\n' +
-      generateEmojiGrid(guesses) +
-      '\n\n' +
-      window.location.href.replace(`${window.location.protocol}//`, '')
-  )
+  const now = new Date()
+  const yyyy = now.getUTCFullYear()
+  const mm = String(now.getUTCMonth() + 1).padStart(2, '0')
+  const dd = String(now.getUTCDate()).padStart(2, '0')
+
+  const shareText =
+    `Wor\u{1F517}dle ${yyyy}/${mm}/${dd}` +
+    ' ' +
+    `${lost ? 'X' : guesses.length}` +
+    '/' +
+    CONFIG.tries.toString() +
+    '\n\n' +
+    generateEmojiGrid(guesses) +
+    '\n\n' +
+    window.location.href.replace(`${window.location.protocol}//`, '')
+
+  navigator.clipboard.writeText(shareText)
 }
 
 export const generateEmojiGrid = (guesses: string[][]) => {
   return guesses
-    .map((guess) => {
+    .map((guess, gi) => {
       const status = getGuessStatuses(guess)
-      return guess
-        .map((letter, i) => {
+      const row = guess
+        .map((_, i) => {
           switch (status[i]) {
             case 'correct':
               return '🟩'
             case 'present':
-              return '🟨'
+              return '🟪'
             default:
               return '⬜'
           }
         })
         .join('')
+
+      const isLast = gi === guesses.length - 1
+      const exitsRight = !isLast && gi % 2 === 0
+      const exitsLeft = !isLast && gi % 2 === 1
+      const entersRight = gi > 0 && gi % 2 === 1
+      const entersLeft = gi > 0 && gi % 2 === 0
+
+      const left = entersLeft ? '└' : exitsLeft ? '┌' : '─'
+      const right = entersRight ? '┘' : exitsRight ? '┐' : '─'
+
+      return left + row + right
     })
     .join('\n')
 }


### PR DESCRIPTION
## Summary
- 공유 헤더를 `English{index}`에서 `Wor🔗dle yyyy/mm/dd`로 변경 (UTC 날짜 기반)
- present 이모지를 🟨에서 🟪로 변경 (게임 퍼플 테마에 맞춤)
- box-drawing 코너 문자(┐┘┌└─)로 snake chain 경로 시각화
- `solutionIndex` 의존성 제거

## Share output example
```
Wor🔗dle 2026/02/16 X/6

─⬜⬜⬜⬜🟩┐
┌⬜⬜⬜⬜🟩┘
└🟪⬜🟪🟪⬜┐
┌🟪⬜🟪⬜⬜┘
└🟪🟪⬜⬜🟩┐
─🟩🟩⬜⬜🟩┘

ootzk.github.io/Wor-chain-dle
```

## Test plan
- [x] 데스크톱 Chrome에서 Share 버튼 → 클립보드 복사 확인
- [x] Android Chrome (HTTPS)에서 Share 버튼 → 클립보드 복사 확인
- [x] 이모지 그리드 정렬 및 box-drawing 문자 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)