### PR TITLE
feat: add Settings modal (#27)

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -25,6 +25,8 @@
     "bestStreak": "Best streak",
     "newWordCountdown": "New word in",
     "share": "Share",
+    "settings": "Settings",
+    "settingsDescription": "Settings will be available soon.",
     "winMessages": [
         "Great Job!",
         "Awesome",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -21,6 +21,8 @@
   "bestStreak": "Mejor racha",
   "newWordCountdown": "Nueva palabra en",
   "share": "Compartir",
+  "settings": "Configuración",
+  "settingsDescription": "La configuración estará disponible pronto.",
   "winMessages": ["¡Gran trabajo!", "Increíble", "¡Bien hecho!"],
   "firstExampleWord": [
     {

--- a/public/locales/sw/translation.json
+++ b/public/locales/sw/translation.json
@@ -21,6 +21,8 @@
   "bestStreak": "Mara bora ya kushinda moja kwa moja",
   "newWordCountdown": "Mchezo mpya kwa",
   "share": "Gawana",
+  "settings": "Mipangilio",
+  "settingsDescription": "Mipangilio itapatikana hivi karibuni.",
   "winMessages": ["Hongera!", "Makofi", "Pongezi!"],
   "firstExampleWord": [
     {

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -21,6 +21,8 @@
   "bestStreak": "最佳連續獲勝次數",
   "newWordCountdown": "距離下個新單詞出現還有",
   "share": "分享",
+  "settings": "設定",
+  "settingsDescription": "設定功能即將推出。",
   "firstExampleWord": [
     {
       "letter": "W",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { InformationCircleIcon } from '@heroicons/react/outline'
 import { ChartBarIcon } from '@heroicons/react/outline'
+import { CogIcon } from '@heroicons/react/outline'
 import { TranslateIcon } from '@heroicons/react/outline'
 import { useState, useEffect } from 'react'
 import { Alert } from './components/alerts/Alert'
@@ -7,6 +8,7 @@ import { Grid } from './components/grid/Grid'
 import { Keyboard } from './components/keyboard/Keyboard'
 import { AboutModal } from './components/modals/AboutModal'
 import { InfoModal } from './components/modals/InfoModal'
+import { SettingsModal } from './components/modals/SettingsModal'
 import { StatsModal } from './components/modals/StatsModal'
 import { TranslateModal } from './components/modals/TranslateModal'
 import { isWordInWordList, isWinningWord, solution } from './lib/words'
@@ -34,6 +36,7 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
   const [isNotEnoughLetters, setIsNotEnoughLetters] = useState(false)
   const [isStatsModalOpen, setIsStatsModalOpen] = useState(false)
   const [isI18nModalOpen, setIsI18nModalOpen] = useState(false)
+  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false)
   const [isWordNotFoundAlertOpen, setIsWordNotFoundAlertOpen] = useState(false)
   const [isGameLost, setIsGameLost] = useState(false)
   const [successAlert, setSuccessAlert] = useState('')
@@ -193,6 +196,10 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
           className="h-6 w-6 cursor-pointer"
           onClick={() => setIsStatsModalOpen(true)}
         />
+        <CogIcon
+          className="h-6 w-6 cursor-pointer"
+          onClick={() => setIsSettingsModalOpen(true)}
+        />
       </div>
       <Grid guesses={guesses} currentGuess={currentGuess} />
       <Keyboard
@@ -220,6 +227,10 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
           setSuccessAlert(t('gameCopied'))
           return setTimeout(() => setSuccessAlert(''), ALERT_TIME_MS)
         }}
+      />
+      <SettingsModal
+        isOpen={isSettingsModalOpen}
+        handleClose={() => setIsSettingsModalOpen(false)}
       />
       <AboutModal
         isOpen={isAboutModalOpen}

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -1,0 +1,16 @@
+import { BaseModal } from './BaseModal'
+import { useTranslation } from 'react-i18next'
+
+type Props = {
+  isOpen: boolean
+  handleClose: () => void
+}
+
+export const SettingsModal = ({ isOpen, handleClose }: Props) => {
+  const { t } = useTranslation()
+  return (
+    <BaseModal title={t('settings')} isOpen={isOpen} handleClose={handleClose}>
+      <p className="text-sm text-gray-500">{t('settingsDescription')}</p>
+    </BaseModal>
+  )
+}


### PR DESCRIPTION
## Summary
- 헤더에 톱니바퀴(CogIcon) 아이콘 추가
- Settings 모달 껍데기 구현 (BaseModal 패턴)
- 아이콘 순서: Info → Stats → Settings
- 4개 언어 번역 키 추가

Closes #27

## Test plan
- [x] 로컬에서 톱니바퀴 아이콘 표시 확인
- [x] 클릭 시 Settings 모달 열림/닫힘 확인
- [x] `npm run build` 성공

🤖 Generated with [Claude Code](https://claude.com/claude-code)