### PR TITLE
feat: add uppercase toggle in Settings

### DIFF
--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -26,7 +26,7 @@
     "newWordCountdown": "New word in",
     "share": "Share",
     "settings": "Settings",
-    "settingsDescription": "Settings will be available soon.",
+    "uppercaseLabel": "Uppercase Letters",
     "winMessages": [
         "Great Job!",
         "Awesome",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -22,7 +22,7 @@
   "newWordCountdown": "Nueva palabra en",
   "share": "Compartir",
   "settings": "Configuración",
-  "settingsDescription": "La configuración estará disponible pronto.",
+  "uppercaseLabel": "Letras mayúsculas",
   "winMessages": ["¡Gran trabajo!", "Increíble", "¡Bien hecho!"],
   "firstExampleWord": [
     {

--- a/public/locales/sw/translation.json
+++ b/public/locales/sw/translation.json
@@ -22,7 +22,7 @@
   "newWordCountdown": "Mchezo mpya kwa",
   "share": "Gawana",
   "settings": "Mipangilio",
-  "settingsDescription": "Mipangilio itapatikana hivi karibuni.",
+  "uppercaseLabel": "Herufi kubwa",
   "winMessages": ["Hongera!", "Makofi", "Pongezi!"],
   "firstExampleWord": [
     {

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -22,7 +22,7 @@
   "newWordCountdown": "距離下個新單詞出現還有",
   "share": "分享",
   "settings": "設定",
-  "settingsDescription": "設定功能即將推出。",
+  "uppercaseLabel": "大寫字母",
   "firstExampleWord": [
     {
       "letter": "W",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,6 +16,8 @@ import { addStatsForCompletedGame, loadStats } from './lib/stats'
 import {
   loadGameStateFromLocalStorage,
   saveGameStateToLocalStorage,
+  loadSettings,
+  saveSettings,
 } from './lib/localStorage'
 
 import { CONFIG } from './constants/config'
@@ -37,6 +39,9 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
   const [isStatsModalOpen, setIsStatsModalOpen] = useState(false)
   const [isI18nModalOpen, setIsI18nModalOpen] = useState(false)
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false)
+  const [isUppercase, setIsUppercase] = useState(
+    () => loadSettings().isUppercase
+  )
   const [isWordNotFoundAlertOpen, setIsWordNotFoundAlertOpen] = useState(false)
   const [isGameLost, setIsGameLost] = useState(false)
   const [successAlert, setSuccessAlert] = useState('')
@@ -81,6 +86,10 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
   useEffect(() => {
     saveGameStateToLocalStorage({ guesses, solution })
   }, [guesses])
+
+  useEffect(() => {
+    saveSettings({ isUppercase })
+  }, [isUppercase])
 
   useEffect(() => {
     if (isGameWon) {
@@ -201,13 +210,15 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
           onClick={() => setIsSettingsModalOpen(true)}
         />
       </div>
-      <Grid guesses={guesses} currentGuess={currentGuess} />
-      <Keyboard
-        onChar={onChar}
-        onDelete={onDelete}
-        onEnter={onEnter}
-        guesses={guesses}
-      />
+      <div className={isUppercase ? 'uppercase' : ''}>
+        <Grid guesses={guesses} currentGuess={currentGuess} />
+        <Keyboard
+          onChar={onChar}
+          onDelete={onDelete}
+          onEnter={onEnter}
+          guesses={guesses}
+        />
+      </div>
       <TranslateModal
         isOpen={isI18nModalOpen}
         handleClose={() => setIsI18nModalOpen(false)}
@@ -231,6 +242,8 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
       <SettingsModal
         isOpen={isSettingsModalOpen}
         handleClose={() => setIsSettingsModalOpen(false)}
+        isUppercase={isUppercase}
+        onToggleUppercase={() => setIsUppercase(!isUppercase)}
       />
       <AboutModal
         isOpen={isAboutModalOpen}

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -4,13 +4,39 @@ import { useTranslation } from 'react-i18next'
 type Props = {
   isOpen: boolean
   handleClose: () => void
+  isUppercase: boolean
+  onToggleUppercase: () => void
 }
 
-export const SettingsModal = ({ isOpen, handleClose }: Props) => {
+export const SettingsModal = ({
+  isOpen,
+  handleClose,
+  isUppercase,
+  onToggleUppercase,
+}: Props) => {
   const { t } = useTranslation()
   return (
     <BaseModal title={t('settings')} isOpen={isOpen} handleClose={handleClose}>
-      <p className="text-sm text-gray-500">{t('settingsDescription')}</p>
+      <div className="flex items-center justify-between py-3">
+        <span className="text-sm font-medium text-gray-700">
+          {t('uppercaseLabel')}
+        </span>
+        <button
+          type="button"
+          role="switch"
+          aria-checked={isUppercase}
+          className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
+            isUppercase ? 'bg-green-500' : 'bg-gray-300'
+          }`}
+          onClick={onToggleUppercase}
+        >
+          <span
+            className={`inline-block h-4 w-4 transform rounded-full bg-white transition-transform ${
+              isUppercase ? 'translate-x-6' : 'translate-x-1'
+            }`}
+          />
+        </button>
+      </div>
     </BaseModal>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -1,6 +1,10 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+.uppercase button {
+  text-transform: uppercase;
+}
 div {
   font-family: 'BCSans', 'Noto Sans', sans-serif;
 }

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -33,3 +33,18 @@ export const loadStatsFromLocalStorage = () => {
   const stats = localStorage.getItem(gameStatKey)
   return stats ? (JSON.parse(stats) as GameStats) : null
 }
+
+const settingsKey = 'settings'
+
+export type Settings = {
+  isUppercase: boolean
+}
+
+export const saveSettings = (settings: Settings) => {
+  localStorage.setItem(settingsKey, JSON.stringify(settings))
+}
+
+export const loadSettings = (): Settings => {
+  const settings = localStorage.getItem(settingsKey)
+  return settings ? (JSON.parse(settings) as Settings) : { isUppercase: false }
+}


### PR DESCRIPTION
## Summary
- Settings 모달에 대/소문자 토글 스위치 추가
- 토글 ON 시 그리드 타일 + 키보드 모두 대문자 표시
- 게임 중간에도 실시간 전환 가능
- 설정값 localStorage에 저장 (새로고침 후에도 유지)

Closes #23

## Test plan
- [x] Settings 모달에서 토글 ON → 그리드/키보드 대문자 표시
- [x] 토글 OFF → 소문자 복귀
- [x] 게임 중간에 토글해도 즉시 반영
- [x] 새로고침 후에도 설정 유지

🤖 Generated with [Claude Code](https://claude.com/claude-code)