### PR TITLE
feat: add practice mode with random words (#24)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "wor-chain-dle",
-    "version": "0.2.0",
+    "version": "1.0.1",
     "lockfileVersion": 2,
     "requires": true,
     "packages": {
         "": {
             "name": "wor-chain-dle",
-            "version": "0.2.0",
+            "version": "1.0.1",
             "dependencies": {
                 "@bcgov/bc-sans": "^1.0.1",
                 "@headlessui/react": "^1.4.2",
@@ -27,11 +27,13 @@
                 "react-dom": "^17.0.2",
                 "react-ga": "^3.3.0",
                 "react-i18next": "^11.15.4",
+                "react-router-dom": "^5.3.4",
                 "react-scripts": "5.0.0",
                 "typescript": "^4.5.4",
                 "web-vitals": "^2.1.3"
             },
             "devDependencies": {
+                "@types/react-router-dom": "^5.3.3",
                 "autoprefixer": "^10.4.2",
                 "gh-pages": "^3.2.3",
                 "husky": "^7.0.4",
@@ -3523,6 +3525,12 @@
                 "@types/node": "*"
             }
         },
+        "node_modules/@types/history": {
+            "version": "4.7.11",
+            "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+            "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+            "dev": true
+        },
         "node_modules/@types/html-minifier-terser": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -3632,6 +3640,27 @@
             "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
             "dependencies": {
                 "@types/react": "*"
+            }
+        },
+        "node_modules/@types/react-router": {
+            "version": "5.1.20",
+            "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+            "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+            "dev": true,
+            "dependencies": {
+                "@types/history": "^4.7.11",
+                "@types/react": "*"
+            }
+        },
+        "node_modules/@types/react-router-dom": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+            "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+            "dev": true,
+            "dependencies": {
+                "@types/history": "^4.7.11",
+                "@types/react": "*",
+                "@types/react-router": "*"
             }
         },
         "node_modules/@types/resolve": {
@@ -8253,6 +8282,32 @@
             "bin": {
                 "he": "bin/he"
             }
+        },
+        "node_modules/history": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+            "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+            "dependencies": {
+                "@babel/runtime": "^7.1.2",
+                "loose-envify": "^1.2.0",
+                "resolve-pathname": "^3.0.0",
+                "tiny-invariant": "^1.0.2",
+                "tiny-warning": "^1.0.0",
+                "value-equal": "^1.0.1"
+            }
+        },
+        "node_modules/hoist-non-react-statics": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+            "dependencies": {
+                "react-is": "^16.7.0"
+            }
+        },
+        "node_modules/hoist-non-react-statics/node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
         },
         "node_modules/hoopy": {
             "version": "0.1.4",
@@ -13819,6 +13874,60 @@
                 "node": ">=0.10.0"
             }
         },
+        "node_modules/react-router": {
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
+            "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+            "dependencies": {
+                "@babel/runtime": "^7.12.13",
+                "history": "^4.9.0",
+                "hoist-non-react-statics": "^3.1.0",
+                "loose-envify": "^1.3.1",
+                "path-to-regexp": "^1.7.0",
+                "prop-types": "^15.6.2",
+                "react-is": "^16.6.0",
+                "tiny-invariant": "^1.0.2",
+                "tiny-warning": "^1.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=15"
+            }
+        },
+        "node_modules/react-router-dom": {
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
+            "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+            "dependencies": {
+                "@babel/runtime": "^7.12.13",
+                "history": "^4.9.0",
+                "loose-envify": "^1.3.1",
+                "prop-types": "^15.6.2",
+                "react-router": "5.3.4",
+                "tiny-invariant": "^1.0.2",
+                "tiny-warning": "^1.0.0"
+            },
+            "peerDependencies": {
+                "react": ">=15"
+            }
+        },
+        "node_modules/react-router/node_modules/isarray": {
+            "version": "0.0.1",
+            "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+            "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+        },
+        "node_modules/react-router/node_modules/path-to-regexp": {
+            "version": "1.9.0",
+            "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+            "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+            "dependencies": {
+                "isarray": "0.0.1"
+            }
+        },
+        "node_modules/react-router/node_modules/react-is": {
+            "version": "16.13.1",
+            "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+            "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+        },
         "node_modules/react-scripts": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.0.tgz",
@@ -14113,6 +14222,11 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/resolve-pathname": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+            "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
         },
         "node_modules/resolve-url-loader": {
             "version": "4.0.0",
@@ -15466,6 +15580,16 @@
             "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
             "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
         },
+        "node_modules/tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+        },
+        "node_modules/tiny-warning": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+            "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+        },
         "node_modules/tmpl": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -15827,6 +15951,11 @@
             "engines": {
                 "node": ">= 8"
             }
+        },
+        "node_modules/value-equal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+            "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
         },
         "node_modules/vary": {
             "version": "1.1.2",
@@ -19199,6 +19328,12 @@
                 "@types/node": "*"
             }
         },
+        "@types/history": {
+            "version": "4.7.11",
+            "resolved": "https://registry.npmjs.org/@types/history/-/history-4.7.11.tgz",
+            "integrity": "sha512-qjDJRrmvBMiTx+jyLxvLfJU7UznFuokDv4f3WRuriHKERccVpFU+8XMQUAbDzoiJCsmexxRExQeMwwCdamSKDA==",
+            "dev": true
+        },
         "@types/html-minifier-terser": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/@types/html-minifier-terser/-/html-minifier-terser-6.1.0.tgz",
@@ -19308,6 +19443,27 @@
             "integrity": "sha512-f96K3k+24RaLGVu/Y2Ng3e1EbZ8/cVJvypZWd7cy0ofCBaf2lcM46xNhycMZ2xGwbBjRql7hOlZ+e2WlJ5MH3Q==",
             "requires": {
                 "@types/react": "*"
+            }
+        },
+        "@types/react-router": {
+            "version": "5.1.20",
+            "resolved": "https://registry.npmjs.org/@types/react-router/-/react-router-5.1.20.tgz",
+            "integrity": "sha512-jGjmu/ZqS7FjSH6owMcD5qpq19+1RS9DeVRqfl1FeBMxTDQAGwlMWOcs52NDoXaNKyG3d1cYQFMs9rCrb88o9Q==",
+            "dev": true,
+            "requires": {
+                "@types/history": "^4.7.11",
+                "@types/react": "*"
+            }
+        },
+        "@types/react-router-dom": {
+            "version": "5.3.3",
+            "resolved": "https://registry.npmjs.org/@types/react-router-dom/-/react-router-dom-5.3.3.tgz",
+            "integrity": "sha512-kpqnYK4wcdm5UaWI3fLcELopqLrHgLqNsdpHauzlQktfkHL3npOSwtj1Uz9oKBAzs7lFtVkV8j83voAz2D8fhw==",
+            "dev": true,
+            "requires": {
+                "@types/history": "^4.7.11",
+                "@types/react": "*",
+                "@types/react-router": "*"
             }
         },
         "@types/resolve": {
@@ -22716,6 +22872,34 @@
             "version": "1.2.0",
             "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
             "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="
+        },
+        "history": {
+            "version": "4.10.1",
+            "resolved": "https://registry.npmjs.org/history/-/history-4.10.1.tgz",
+            "integrity": "sha512-36nwAD620w12kuzPAsyINPWJqlNbij+hpK1k9XRloDtym8mxzGYl2c17LnV6IAGB2Dmg4tEa7G7DlawS0+qjew==",
+            "requires": {
+                "@babel/runtime": "^7.1.2",
+                "loose-envify": "^1.2.0",
+                "resolve-pathname": "^3.0.0",
+                "tiny-invariant": "^1.0.2",
+                "tiny-warning": "^1.0.0",
+                "value-equal": "^1.0.1"
+            }
+        },
+        "hoist-non-react-statics": {
+            "version": "3.3.2",
+            "resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
+            "integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
+            "requires": {
+                "react-is": "^16.7.0"
+            },
+            "dependencies": {
+                "react-is": {
+                    "version": "16.13.1",
+                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+                    "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+                }
+            }
         },
         "hoopy": {
             "version": "0.1.4",
@@ -26603,6 +26787,56 @@
             "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
             "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
         },
+        "react-router": {
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/react-router/-/react-router-5.3.4.tgz",
+            "integrity": "sha512-Ys9K+ppnJah3QuaRiLxk+jDWOR1MekYQrlytiXxC1RyfbdsZkS5pvKAzCCr031xHixZwpnsYNT5xysdFHQaYsA==",
+            "requires": {
+                "@babel/runtime": "^7.12.13",
+                "history": "^4.9.0",
+                "hoist-non-react-statics": "^3.1.0",
+                "loose-envify": "^1.3.1",
+                "path-to-regexp": "^1.7.0",
+                "prop-types": "^15.6.2",
+                "react-is": "^16.6.0",
+                "tiny-invariant": "^1.0.2",
+                "tiny-warning": "^1.0.0"
+            },
+            "dependencies": {
+                "isarray": {
+                    "version": "0.0.1",
+                    "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+                    "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ=="
+                },
+                "path-to-regexp": {
+                    "version": "1.9.0",
+                    "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.9.0.tgz",
+                    "integrity": "sha512-xIp7/apCFJuUHdDLWe8O1HIkb0kQrOMb/0u6FXQjemHn/ii5LrIzU6bdECnsiTF/GjZkMEKg1xdiZwNqDYlZ6g==",
+                    "requires": {
+                        "isarray": "0.0.1"
+                    }
+                },
+                "react-is": {
+                    "version": "16.13.1",
+                    "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+                    "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+                }
+            }
+        },
+        "react-router-dom": {
+            "version": "5.3.4",
+            "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-5.3.4.tgz",
+            "integrity": "sha512-m4EqFMHv/Ih4kpcBCONHbkT68KoAeHN4p3lAGoNryfHi0dMy0kCzEZakiKRsvg5wHZ/JLrLW8o8KomWiz/qbYQ==",
+            "requires": {
+                "@babel/runtime": "^7.12.13",
+                "history": "^4.9.0",
+                "loose-envify": "^1.3.1",
+                "prop-types": "^15.6.2",
+                "react-router": "5.3.4",
+                "tiny-invariant": "^1.0.2",
+                "tiny-warning": "^1.0.0"
+            }
+        },
         "react-scripts": {
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/react-scripts/-/react-scripts-5.0.0.tgz",
@@ -26825,6 +27059,11 @@
             "version": "5.0.0",
             "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-5.0.0.tgz",
             "integrity": "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="
+        },
+        "resolve-pathname": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/resolve-pathname/-/resolve-pathname-3.0.0.tgz",
+            "integrity": "sha512-C7rARubxI8bXFNB/hqcp/4iUeIXJhJZvFPFPiSPRnhU5UPxzMFIl+2E6yY6c4k9giDJAhtV+enfA+G89N6Csng=="
         },
         "resolve-url-loader": {
             "version": "4.0.0",
@@ -27816,6 +28055,16 @@
             "resolved": "https://registry.npmjs.org/timsort/-/timsort-0.3.0.tgz",
             "integrity": "sha1-QFQRqOfmM5/mTbmiNN4R3DHgK9Q="
         },
+        "tiny-invariant": {
+            "version": "1.3.3",
+            "resolved": "https://registry.npmjs.org/tiny-invariant/-/tiny-invariant-1.3.3.tgz",
+            "integrity": "sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg=="
+        },
+        "tiny-warning": {
+            "version": "1.0.3",
+            "resolved": "https://registry.npmjs.org/tiny-warning/-/tiny-warning-1.0.3.tgz",
+            "integrity": "sha512-lBN9zLN/oAf68o3zNXYrdCt1kP8WsiGW8Oo2ka41b2IM5JL/S1CTyX1rW0mb/zSuJun0ZUrDxx4sqvYS2FWzPA=="
+        },
         "tmpl": {
             "version": "1.0.5",
             "resolved": "https://registry.npmjs.org/tmpl/-/tmpl-1.0.5.tgz",
@@ -28087,6 +28336,11 @@
                     "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ=="
                 }
             }
+        },
+        "value-equal": {
+            "version": "1.0.1",
+            "resolved": "https://registry.npmjs.org/value-equal/-/value-equal-1.0.1.tgz",
+            "integrity": "sha512-NOJ6JZCAWr0zlxZt+xqCHNTEKOsrks2HQd4MqhP1qy4z1SkbEP467eNx6TgDKXMvUOb+OENfJCZwM+16n7fRfw=="
         },
         "vary": {
             "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
         "react-dom": "^17.0.2",
         "react-ga": "^3.3.0",
         "react-i18next": "^11.15.4",
+        "react-router-dom": "^5.3.4",
         "react-scripts": "5.0.0",
         "typescript": "^4.5.4",
         "web-vitals": "^2.1.3"
@@ -57,6 +58,7 @@
         ]
     },
     "devDependencies": {
+        "@types/react-router-dom": "^5.3.3",
         "autoprefixer": "^10.4.2",
         "gh-pages": "^3.2.3",
         "husky": "^7.0.4",

--- a/public/index.html
+++ b/public/index.html
@@ -39,6 +39,7 @@
       To create a production bundle, use `npm run build` or `yarn build`.
     -->
     <!-- GoatCounter analytics -->
+    <script>window.goatcounter = { path: function(p) { var h = location.hash; return h && h !== '#/' ? p + h : p } }</script>
     <script data-goatcounter="https://wor-chain-dle.goatcounter.com/count"
             async src="//gc.zgo.at/count.js"></script>
 </body>

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -27,6 +27,9 @@
     "share": "Share",
     "settings": "Settings",
     "uppercaseLabel": "Uppercase Letters",
+    "practice": "Practice",
+    "daily": "Daily",
+    "playAgain": "Play Again",
     "winMessages": [
         "Great Job!",
         "Awesome",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -23,6 +23,9 @@
   "share": "Compartir",
   "settings": "Configuración",
   "uppercaseLabel": "Letras mayúsculas",
+  "practice": "Práctica",
+  "daily": "Diario",
+  "playAgain": "Jugar de nuevo",
   "winMessages": ["¡Gran trabajo!", "Increíble", "¡Bien hecho!"],
   "firstExampleWord": [
     {

--- a/public/locales/sw/translation.json
+++ b/public/locales/sw/translation.json
@@ -23,6 +23,9 @@
   "share": "Gawana",
   "settings": "Mipangilio",
   "uppercaseLabel": "Herufi kubwa",
+  "practice": "Mazoezi",
+  "daily": "Kila siku",
+  "playAgain": "Cheza tena",
   "winMessages": ["Hongera!", "Makofi", "Pongezi!"],
   "firstExampleWord": [
     {

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -23,6 +23,9 @@
   "share": "分享",
   "settings": "設定",
   "uppercaseLabel": "大寫字母",
+  "practice": "練習",
+  "daily": "每日挑戰",
+  "playAgain": "再玩一次",
   "firstExampleWord": [
     {
       "letter": "W",

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -1,5 +1,7 @@
 import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
 import App from './App'
+import { solution } from './lib/words'
 import { ORTHOGRAPHY } from './constants/orthography'
 import { WORDS } from './constants/wordlist'
 import { ORTHOGRAPHY_PATTERN } from './lib/tokenizer'
@@ -7,7 +9,11 @@ import { CONFIG } from './constants/config'
 import chalk from 'chalk'
 
 test('renders game', () => {
-  render(<App />)
+  render(
+    <MemoryRouter>
+      <App mode="daily" solution={solution} />
+    </MemoryRouter>
+  )
   const titleElement = screen.getByText(/Wor.*dle/i)
   expect(titleElement).toBeInTheDocument()
 })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,15 +3,16 @@ import { ChartBarIcon } from '@heroicons/react/outline'
 import { CogIcon } from '@heroicons/react/outline'
 import { TranslateIcon } from '@heroicons/react/outline'
 import { useState, useEffect } from 'react'
+import { Link } from 'react-router-dom'
 import { Alert } from './components/alerts/Alert'
 import { Grid } from './components/grid/Grid'
 import { Keyboard } from './components/keyboard/Keyboard'
 import { AboutModal } from './components/modals/AboutModal'
 import { InfoModal } from './components/modals/InfoModal'
 import { SettingsModal } from './components/modals/SettingsModal'
-import { StatsModal } from './components/modals/StatsModal'
+import { StatsModal, GameMode } from './components/modals/StatsModal'
 import { TranslateModal } from './components/modals/TranslateModal'
-import { isWordInWordList, isWinningWord, solution } from './lib/words'
+import { isWordInWordList, isWinningWord } from './lib/words'
 import { addStatsForCompletedGame, loadStats } from './lib/stats'
 import {
   loadGameStateFromLocalStorage,
@@ -30,7 +31,19 @@ import { withTranslation, WithTranslation } from 'react-i18next'
 
 const ALERT_TIME_MS = 2000
 
-const App: React.FC<WithTranslation> = ({ t, i18n }) => {
+type AppOwnProps = {
+  mode: GameMode
+  solution: string
+}
+
+const App: React.FC<WithTranslation & AppOwnProps> = ({
+  t,
+  i18n,
+  mode,
+  solution,
+}) => {
+  const isDaily = mode === 'daily'
+
   const [currentGuess, setCurrentGuess] = useState<Array<string>>([])
   const [isGameWon, setIsGameWon] = useState(false)
   const [isInfoModalOpen, setIsInfoModalOpen] = useState(false)
@@ -46,6 +59,7 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
   const [isGameLost, setIsGameLost] = useState(false)
   const [successAlert, setSuccessAlert] = useState('')
   const [guesses, setGuesses] = useState<string[][]>(() => {
+    if (!isDaily) return []
     const loaded = loadGameStateFromLocalStorage()
     if (loaded?.solution !== solution) {
       return []
@@ -76,16 +90,22 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
   const [stats, setStats] = useState(() => loadStats())
 
   useEffect(() => {
-    const now = new Date()
-    const yyyy = now.getUTCFullYear()
-    const mm = String(now.getUTCMonth() + 1).padStart(2, '0')
-    const dd = String(now.getUTCDate()).padStart(2, '0')
-    document.title = `Wor\u{1F517}dle ${yyyy}-${mm}-${dd}`
-  }, [])
+    if (isDaily) {
+      const now = new Date()
+      const yyyy = now.getUTCFullYear()
+      const mm = String(now.getUTCMonth() + 1).padStart(2, '0')
+      const dd = String(now.getUTCDate()).padStart(2, '0')
+      document.title = `Wor\u{1F517}dle ${yyyy}-${mm}-${dd}`
+    } else {
+      document.title = `Wor\u{1F517}dle Practice`
+    }
+  }, [isDaily])
 
   useEffect(() => {
-    saveGameStateToLocalStorage({ guesses, solution })
-  }, [guesses])
+    if (isDaily) {
+      saveGameStateToLocalStorage({ guesses, solution })
+    }
+  }, [guesses, isDaily, solution])
 
   useEffect(() => {
     saveSettings({ isUppercase })
@@ -151,14 +171,16 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
         setIsWordNotFoundAlertOpen(false)
       }, ALERT_TIME_MS)
     }
-    const winningWord = isWinningWord(fullGuess.join(''))
+    const winningWord = isWinningWord(fullGuess.join(''), solution)
 
     if (guesses.length < CONFIG.tries && !isGameWon) {
       setCurrentGuess([])
       setGuesses([...guesses, fullGuess])
 
       if (winningWord) {
-        setStats(addStatsForCompletedGame(stats, guesses.length))
+        if (isDaily) {
+          setStats(addStatsForCompletedGame(stats, guesses.length))
+        }
         return setIsGameWon(true)
       }
 
@@ -168,14 +190,18 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
           .split(ORTHOGRAPHY_PATTERN)
           .filter((i) => i)
         if (isChainDeadEnd(newGuesses, solutionChars)) {
-          setStats(addStatsForCompletedGame(stats, CONFIG.tries))
+          if (isDaily) {
+            setStats(addStatsForCompletedGame(stats, CONFIG.tries))
+          }
           setIsGameLost(true)
           return
         }
       }
 
       if (guesses.length === CONFIG.tries - 1) {
-        setStats(addStatsForCompletedGame(stats, guesses.length + 1))
+        if (isDaily) {
+          setStats(addStatsForCompletedGame(stats, guesses.length + 1))
+        }
         setIsGameLost(true)
       }
     }
@@ -194,29 +220,48 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
     <div className="py-8 max-w-7xl mx-auto sm:px-6 lg:px-8">
       <div className="flex w-80 mx-auto items-center mb-8">
         <h1 className="text-xl grow font-bold">
-          Wor&#x1F517;dle {new Date().toLocaleDateString('en-CA')}
+          {isDaily ? (
+            <>Wor&#x1F517;dle {new Date().toLocaleDateString('en-CA')}</>
+          ) : (
+            <>Wor&#x1F517;dle Practice</>
+          )}
         </h1>
         {translateElement}
         <InformationCircleIcon
           className="h-6 w-6 cursor-pointer"
           onClick={() => setIsInfoModalOpen(true)}
         />
-        <ChartBarIcon
-          className="h-6 w-6 cursor-pointer"
-          onClick={() => setIsStatsModalOpen(true)}
-        />
+        {isDaily && (
+          <ChartBarIcon
+            className="h-6 w-6 cursor-pointer"
+            onClick={() => setIsStatsModalOpen(true)}
+          />
+        )}
         <CogIcon
           className="h-6 w-6 cursor-pointer"
           onClick={() => setIsSettingsModalOpen(true)}
         />
       </div>
+      <div className="flex justify-center mb-4">
+        <Link
+          to={isDaily ? '/practice' : '/'}
+          className="text-xs font-medium text-indigo-600 hover:text-indigo-500"
+        >
+          {isDaily ? t('practice') : t('daily')}
+        </Link>
+      </div>
       <div className={isUppercase ? 'uppercase' : ''}>
-        <Grid guesses={guesses} currentGuess={currentGuess} />
+        <Grid
+          guesses={guesses}
+          currentGuess={currentGuess}
+          solution={solution}
+        />
         <Keyboard
           onChar={onChar}
           onDelete={onDelete}
           onEnter={onEnter}
           guesses={guesses}
+          solution={solution}
         />
       </div>
       <TranslateModal
@@ -238,6 +283,8 @@ const App: React.FC<WithTranslation> = ({ t, i18n }) => {
           setSuccessAlert(t('gameCopied'))
           return setTimeout(() => setSuccessAlert(''), ALERT_TIME_MS)
         }}
+        mode={mode}
+        solution={solution}
       />
       <SettingsModal
         isOpen={isSettingsModalOpen}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -242,14 +242,6 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
           onClick={() => setIsSettingsModalOpen(true)}
         />
       </div>
-      <div className="flex justify-center mb-4">
-        <Link
-          to={isDaily ? '/practice' : '/'}
-          className="text-xs font-medium text-indigo-600 hover:text-indigo-500"
-        >
-          {isDaily ? t('practice') : t('daily')}
-        </Link>
-      </div>
       <div className={isUppercase ? 'uppercase' : ''}>
         <Grid
           guesses={guesses}
@@ -297,13 +289,21 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
         handleClose={() => setIsAboutModalOpen(false)}
       />
 
-      <button
-        type="button"
-        className="mx-auto mt-8 flex items-center px-2.5 py-1.5 border border-transparent text-xs font-medium rounded text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 select-none"
-        onClick={() => setIsAboutModalOpen(true)}
-      >
-        {t('about')}
-      </button>
+      <div className="mx-auto mt-8 flex items-center justify-center gap-2">
+        <button
+          type="button"
+          className="flex items-center px-2.5 py-1.5 border border-transparent text-xs font-medium rounded text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 select-none"
+          onClick={() => setIsAboutModalOpen(true)}
+        >
+          {t('about')}
+        </button>
+        <Link
+          to={isDaily ? '/practice' : '/'}
+          className="flex items-center px-2.5 py-1.5 border border-transparent text-xs font-medium rounded text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 select-none"
+        >
+          {isDaily ? t('practice') : t('daily')}
+        </Link>
+      </div>
 
       <Alert message={t('notEnoughLetters')} isOpen={isNotEnoughLetters} />
       <Alert message={t('wordNotFound')} isOpen={isWordNotFoundAlertOpen} />

--- a/src/components/grid/CompletedRow.tsx
+++ b/src/components/grid/CompletedRow.tsx
@@ -3,16 +3,18 @@ import { Cell } from './Cell'
 
 type Props = {
   guess: string[]
+  solution: string
   chainTopIndex?: number
   chainBottomIndex?: number
 }
 
 export const CompletedRow = ({
   guess,
+  solution,
   chainTopIndex,
   chainBottomIndex,
 }: Props) => {
-  const statuses = getGuessStatuses(guess)
+  const statuses = getGuessStatuses(guess, solution)
 
   return (
     <div className="flex justify-center mb-1">

--- a/src/components/grid/CurrentRow.tsx
+++ b/src/components/grid/CurrentRow.tsx
@@ -6,6 +6,7 @@ import { CharStatus, getGuessStatuses } from '../../lib/statuses'
 type Props = {
   guess: string[]
   guesses: string[][]
+  solution: string
   chainTopIndex?: number
   chainBottomIndex?: number
 }
@@ -13,6 +14,7 @@ type Props = {
 export const CurrentRow = ({
   guess,
   guesses,
+  solution,
   chainTopIndex,
   chainBottomIndex,
 }: Props) => {
@@ -21,7 +23,7 @@ export const CurrentRow = ({
   let chainStatus: CharStatus | undefined
   if (chainInfo) {
     const prev = guesses[guesses.length - 1]
-    const prevStatuses = getGuessStatuses(prev)
+    const prevStatuses = getGuessStatuses(prev, solution)
     const chainPos =
       chainInfo.position === 'first' ? 0 : CONFIG.wordLength - 1
     chainStatus = prevStatuses[chainPos]

--- a/src/components/grid/Grid.tsx
+++ b/src/components/grid/Grid.tsx
@@ -8,6 +8,7 @@ import React from 'react'
 type Props = {
   guesses: string[][]
   currentGuess: string[]
+  solution: string
 }
 
 function getChainPositions(rowIndex: number) {
@@ -30,7 +31,7 @@ function getBridgeChainIndex(rowIndex: number) {
   return rowIndex % 2 === 0 ? CONFIG.wordLength - 1 : 0
 }
 
-export const Grid = ({ guesses, currentGuess }: Props) => {
+export const Grid = ({ guesses, currentGuess, solution }: Props) => {
   const elements: React.ReactNode[] = []
 
   for (let i = 0; i < CONFIG.tries; i++) {
@@ -41,6 +42,7 @@ export const Grid = ({ guesses, currentGuess }: Props) => {
         <CompletedRow
           key={`row-${i}`}
           guess={guesses[i]}
+          solution={solution}
           chainTopIndex={chainTopIndex}
           chainBottomIndex={chainBottomIndex}
         />
@@ -51,6 +53,7 @@ export const Grid = ({ guesses, currentGuess }: Props) => {
           key={`row-${i}`}
           guess={currentGuess}
           guesses={guesses}
+          solution={solution}
           chainTopIndex={chainTopIndex}
           chainBottomIndex={chainBottomIndex}
         />

--- a/src/components/keyboard/Keyboard.tsx
+++ b/src/components/keyboard/Keyboard.tsx
@@ -15,11 +15,18 @@ type Props = {
   onDelete: () => void
   onEnter: () => void
   guesses: string[][]
+  solution: string
 }
 
-export const Keyboard = ({ onChar, onDelete, onEnter, guesses }: Props) => {
+export const Keyboard = ({
+  onChar,
+  onDelete,
+  onEnter,
+  guesses,
+  solution,
+}: Props) => {
   const { t } = useTranslation()
-  const charStatuses = getStatuses(guesses)
+  const charStatuses = getStatuses(guesses, solution)
 
   const onClick = (value: KeyValue) => {
     if (value === 'ENTER') {

--- a/src/components/mini-grid/MiniCompletedRow.tsx
+++ b/src/components/mini-grid/MiniCompletedRow.tsx
@@ -3,10 +3,11 @@ import { MiniCell } from './MiniCell'
 
 type Props = {
   guess: string[]
+  solution: string
 }
 
-export const MiniCompletedRow = ({ guess }: Props) => {
-  const statuses = getGuessStatuses(guess)
+export const MiniCompletedRow = ({ guess, solution }: Props) => {
+  const statuses = getGuessStatuses(guess, solution)
 
   return (
     <div className="flex justify-center mb-1">

--- a/src/components/mini-grid/MiniGrid.tsx
+++ b/src/components/mini-grid/MiniGrid.tsx
@@ -2,13 +2,14 @@ import { MiniCompletedRow } from './MiniCompletedRow'
 
 type Props = {
   guesses: string[][]
+  solution: string
 }
 
-export const MiniGrid = ({ guesses }: Props) => {
+export const MiniGrid = ({ guesses, solution }: Props) => {
   return (
     <div className="pb-6">
       {guesses.map((guess, i) => (
-        <MiniCompletedRow key={i} guess={guess} />
+        <MiniCompletedRow key={i} guess={guess} solution={solution} />
       ))}
     </div>
   )

--- a/src/components/modals/StatsModal.tsx
+++ b/src/components/modals/StatsModal.tsx
@@ -7,6 +7,8 @@ import { tomorrow } from '../../lib/words'
 import { BaseModal } from './BaseModal'
 import { useTranslation } from 'react-i18next'
 
+export type GameMode = 'daily' | 'practice'
+
 type Props = {
   isOpen: boolean
   handleClose: () => void
@@ -15,6 +17,8 @@ type Props = {
   isGameLost: boolean
   isGameWon: boolean
   handleShare: () => void
+  mode: GameMode
+  solution: string
 }
 
 export const StatsModal = ({
@@ -25,8 +29,33 @@ export const StatsModal = ({
   isGameLost,
   isGameWon,
   handleShare,
+  mode,
+  solution,
 }: Props) => {
   const { t } = useTranslation()
+
+  if (mode === 'practice') {
+    return (
+      <BaseModal
+        title={t('statistics')}
+        isOpen={isOpen}
+        handleClose={handleClose}
+      >
+        {(isGameLost || isGameWon) && (
+          <div className="mt-5 sm:mt-6 flex justify-center">
+            <button
+              type="button"
+              className="w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-600 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:text-sm"
+              onClick={() => window.location.reload()}
+            >
+              {t('playAgain')}
+            </button>
+          </div>
+        )}
+      </BaseModal>
+    )
+  }
+
   if (gameStats.totalGames <= 0) {
     return (
       <BaseModal
@@ -63,7 +92,7 @@ export const StatsModal = ({
             type="button"
             className="mt-2 w-full rounded-md border border-transparent shadow-sm px-4 py-2 bg-indigo-600 text-base font-medium text-white hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:text-sm"
             onClick={() => {
-              shareStatus(guesses, isGameLost)
+              shareStatus(guesses, isGameLost, solution)
               handleShare()
             }}
           >

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,12 +1,27 @@
-import React from 'react'
+import React, { useState } from 'react'
 import ReactDOM from 'react-dom'
+import { HashRouter, Route, Switch } from 'react-router-dom'
 import './index.css'
 import App from './App'
+import { solution as dailySolution } from './lib/words'
+import { getRandomWord } from './lib/words'
 import reportWebVitals from './reportWebVitals'
+
+const DailyPage = () => <App mode="daily" solution={dailySolution} />
+
+const PracticePage = () => {
+  const [practiceSolution] = useState(() => getRandomWord())
+  return <App mode="practice" solution={practiceSolution} />
+}
 
 ReactDOM.render(
   <React.StrictMode>
-    <App />
+    <HashRouter>
+      <Switch>
+        <Route exact path="/" component={DailyPage} />
+        <Route path="/practice" component={PracticePage} />
+      </Switch>
+    </HashRouter>
   </React.StrictMode>,
   document.getElementById('root')
 )

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,7 +1,11 @@
 import { getGuessStatuses } from './statuses'
 import { CONFIG } from '../constants/config'
 
-export const shareStatus = (guesses: string[][], lost: boolean) => {
+export const shareStatus = (
+  guesses: string[][],
+  lost: boolean,
+  solution: string
+) => {
   const now = new Date()
   const yyyy = now.getUTCFullYear()
   const mm = String(now.getUTCMonth() + 1).padStart(2, '0')
@@ -14,17 +18,20 @@ export const shareStatus = (guesses: string[][], lost: boolean) => {
     '/' +
     CONFIG.tries.toString() +
     '\n\n' +
-    generateEmojiGrid(guesses) +
+    generateEmojiGrid(guesses, solution) +
     '\n\n' +
     window.location.href.replace(`${window.location.protocol}//`, '')
 
   navigator.clipboard.writeText(shareText)
 }
 
-export const generateEmojiGrid = (guesses: string[][]) => {
+export const generateEmojiGrid = (
+  guesses: string[][],
+  solution: string
+) => {
   return guesses
     .map((guess, gi) => {
-      const status = getGuessStatuses(guess)
+      const status = getGuessStatuses(guess, solution)
       const row = guess
         .map((_, i) => {
           switch (status[i]) {

--- a/src/lib/statuses.ts
+++ b/src/lib/statuses.ts
@@ -1,4 +1,3 @@
-import { solution } from './words'
 import { ORTHOGRAPHY } from '../constants/orthography'
 import { ORTHOGRAPHY_PATTERN } from './tokenizer'
 
@@ -7,7 +6,8 @@ export type CharStatus = 'absent' | 'present' | 'correct'
 export type CharValue = typeof ORTHOGRAPHY[number]
 
 export const getStatuses = (
-  guesses: string[][]
+  guesses: string[][],
+  solution: string
 ): { [key: string]: CharStatus } => {
   const charObj: { [key: string]: CharStatus } = {}
   const solutionChars = solution.split(ORTHOGRAPHY_PATTERN).filter((i) => i)
@@ -33,7 +33,10 @@ export const getStatuses = (
   return charObj
 }
 
-export const getGuessStatuses = (guess: string[]): CharStatus[] => {
+export const getGuessStatuses = (
+  guess: string[],
+  solution: string
+): CharStatus[] => {
   const splitSolution = solution.split(ORTHOGRAPHY_PATTERN).filter((i) => i)
   const splitGuess = guess
 

--- a/src/lib/words.ts
+++ b/src/lib/words.ts
@@ -6,8 +6,12 @@ export const isWordInWordList = (word: string) => {
   return WORDS.includes(word) || VALIDGUESSES.includes(word)
 }
 
-export const isWinningWord = (word: string) => {
-  return solution === word
+export const isWinningWord = (word: string, sol: string) => {
+  return sol === word
+}
+
+export const getRandomWord = () => {
+  return WORDS[Math.floor(Math.random() * WORDS.length)]
 }
 
 export const getWordOfDay = () => {


### PR DESCRIPTION
Closes #24
## Summary
- `/#/practice` 경로에 연습 모드 추가 — 새로고침마다 랜덤 단어 출제
- HashRouter 기반 라우팅 (`/#/` 데일리, `/#/practice` 연습)
- `solution` 전역 의존성을 함수 파라미터로 리팩터 (statuses, share, Grid, Keyboard 등 20개 파일)
- 연습 모드: 통계/공유 없음, 게임 종료 시 "Play Again" 버튼
- GoatCounter 해시 라우트 트래킹 (기존 데일리 경로 데이터 연속성 유지)

## Test plan
- [ ] `/#/` → 기존 데일리 게임 동작 변함없음
- [ ] `/#/practice` → 새로고침마다 다른 단어 출제
- [ ] 연습 모드: 체인 규칙 정상 동작
- [ ] 연습 모드: 게임 종료 시 "Play Again" 표시, 통계/공유 없음
- [ ] 하단 모드 전환 링크 정상 동작
- [ ] 연습 모드 플레이가 데일리 게임 상태에 영향 없음
- [ ] GoatCounter: 데일리 → `/Wor-chain-dle/`, 연습 → `/Wor-chain-dle/#/practice`

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)