### PR TITLE
feat: split header title into two lines

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -228,13 +228,12 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
   return (
     <div className="py-8 max-w-7xl mx-auto sm:px-6 lg:px-8">
       <div className="flex w-80 mx-auto items-center mb-8">
-        <h1 className="text-xl grow font-bold">
-          {isDaily ? (
-            <>Wor&#x1F517;dle {new Date().toLocaleDateString('en-CA')}</>
-          ) : (
-            <>Wor&#x1F517;dle Practice</>
-          )}
-        </h1>
+        <div className="grow">
+          <h1 className="text-xl font-bold">Wor&#x1F517;dle</h1>
+          <p className="text-sm text-gray-500">
+            {isDaily ? new Date().toLocaleDateString('en-CA') : t('practice')}
+          </p>
+        </div>
         {translateElement}
         <InformationCircleIcon
           className="h-6 w-6 cursor-pointer"


### PR DESCRIPTION
## Summary
- 헤더 제목을 2줄 구조로 변경: 1줄 `Wor🔗dle`, 2줄 날짜/Practice
- 아이콘 5개 추가로 인한 레이아웃 깨짐 해결

## Test plan
- [x] Daily 모드: `Wor🔗dle` + `YYYY-MM-DD` 2줄 표시 확인
- [x] Practice 모드: `Wor🔗dle` + `Practice` 2줄 표시 확인
- [x] 아이콘들이 줄바꿈 없이 정렬되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)