### PR TITLE
chore: add Claude skills and update dev guidelines

### DIFF
--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -1,0 +1,22 @@
+---
+name: bump-version
+description: 프로젝트 내 모든 버전 정보를 일괄 업데이트합니다.
+disable-model-invocation: true
+allowed-tools: Read, Edit, Bash(npm version *)
+argument-hint: <version> (e.g. 1.1.0)
+---
+
+# Version Bump
+
+인자로 전달된 버전($ARGUMENTS)으로 프로젝트 내 모든 버전 정보를 업데이트하세요.
+
+## 업데이트 대상
+
+1. `package.json` → `"version"` 필드
+2. `src/constants/config.ts` → `PATCH_NOTES_VERSION` 상수
+
+## 절차
+
+1. `npm version $ARGUMENTS --no-git-tag-version` 으로 package.json, package-lock.json 업데이트
+2. `src/constants/config.ts`의 `PATCH_NOTES_VERSION` 값을 `'$ARGUMENTS'`로 변경
+3. 변경된 파일 목록을 사용자에게 보여줌 (커밋은 하지 않음)

--- a/.claude/skills/cleanup/SKILL.md
+++ b/.claude/skills/cleanup/SKILL.md
@@ -1,0 +1,25 @@
+---
+name: cleanup
+description: feature 브랜치 머지 후 로컬 정리 (release 전환, pull, 브랜치 삭제, prune)
+disable-model-invocation: true
+allowed-tools: Bash(git *)
+---
+
+# Post-Merge Cleanup
+
+feature 브랜치가 머지된 후 로컬 환경을 정리합니다.
+
+## 절차
+
+1. 현재 브랜치 이름을 확인하여 삭제 대상 feature 브랜치를 파악
+2. release 브랜치를 식별 (현재 브랜치가 feature면 대상 release 브랜치를 `git log --oneline --decorate`에서 추론, 아니면 사용자에게 질문)
+3. 아래 명령을 순서대로 실행:
+
+```
+git checkout <release-branch>
+git pull
+git branch -d <feature-branch>
+git remote prune origin
+```
+
+4. 정리 결과를 사용자에게 보여줌

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,7 @@ Based on [AnyLanguage-Word-Guessing-Game](https://github.com/roedoejet/AnyLangua
 
 - React 17 + TypeScript + Tailwind CSS 3
 - Create React App (react-scripts 5)
-- i18next (en, es, sw, zh)
+- i18next (en, ko, ja, es, sw, zh)
 - GoatCounter 애널리틱스 (쿠키 없음, 경량)
 - GitHub Actions → GitHub Pages 자동 배포
 
@@ -57,12 +57,26 @@ docker run -d -p 3000:3000 wor-chain-dle
 - `main` 브랜치에 push 시 GitHub Actions가 `gh-pages` 브랜치로 자동 배포.
 - 수동 배포: `npm run deploy`
 
+## Project Management
+
+- **GitHub Project Board**: https://github.com/users/Ootzk/projects/3 에서 작업 관리.
+- 작업 단위는 보드의 이슈로 추적하되, 즉흥적으로 개발하는 경우도 있음. 그 경우에도 연관 작업끼리 PR 단위로 묶어 보드에 연동.
+
 ## Git Branching Strategy
 
 - `main`: 항상 배포 가능한 상태. 머지될 때마다 버전 태그 등록.
 - `release/{version}`: 다음 버전 개발 브랜치. main에서 생성. 해당 버전이 어느 정도 완성되면 main으로 PR을 보내서 머지.
 - `feature/{contents}`: 기능별 브랜치. release 브랜치에서 생성. 작업 완료 후 release 브랜치로 PR을 만들어서 머지.
 - **PR 머지는 항상 개발자가 직접 수행.** Claude는 PR 생성까지만.
+- **PR 생성 시 반드시 `--repo Ootzk/Wor-chain-dle`을 명시한다.** 이 프로젝트는 fork 기반이므로, `--repo` 없이 `gh pr create`를 실행하면 upstream(원본 저장소)으로 PR이 올라갈 수 있다.
+
+## Version Management
+
+코드 내 버전 정보가 있는 곳:
+- `package.json` → `"version"` 필드
+- `src/constants/config.ts` → `PATCH_NOTES_VERSION` 상수
+
+`release/{version}` 브랜치를 `main`으로 PR할 때 위 두 값이 해당 버전과 반드시 일치해야 한다. `/bump-version` 스킬로 일괄 업데이트 가능.
 
 ## Snake Chain Rule
 


### PR DESCRIPTION
## Summary
- `/bump-version <version>` 스킬 추가 — package.json + PATCH_NOTES_VERSION 일괄 업데이트
- `/cleanup` 스킬 추가 — feature 머지 후 로컬 정리 자동화
- CLAUDE.md 업데이트: Project Board 관리, fork PR 규칙, Version Management 섹션

## Test plan
- [ ] `/bump-version 1.1.0` 실행하여 버전 업데이트 동작 확인
- [ ] `/cleanup` 실행하여 로컬 정리 동작 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)