### PR TITLE
chore: add README badge to bump-version skill

### DIFF
--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -14,9 +14,11 @@ argument-hint: <version> (e.g. 1.1.0)
 
 1. `package.json` → `"version"` 필드
 2. `src/constants/config.ts` → `PATCH_NOTES_VERSION` 상수
+3. `README.md` → 버전 뱃지 (`![Version](https://img.shields.io/badge/Version-v...-blue)`)
 
 ## 절차
 
 1. `npm version $ARGUMENTS --no-git-tag-version` 으로 package.json, package-lock.json 업데이트
 2. `src/constants/config.ts`의 `PATCH_NOTES_VERSION` 값을 `'$ARGUMENTS'`로 변경
+3. `README.md`의 버전 뱃지를 `v$ARGUMENTS`로 변경
 3. 변경된 파일 목록을 사용자에게 보여줌 (커밋은 하지 않음)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -75,8 +75,9 @@ docker run -d -p 3000:3000 wor-chain-dle
 코드 내 버전 정보가 있는 곳:
 - `package.json` → `"version"` 필드
 - `src/constants/config.ts` → `PATCH_NOTES_VERSION` 상수
+- `README.md` → 버전 뱃지
 
-`release/{version}` 브랜치를 `main`으로 PR할 때 위 두 값이 해당 버전과 반드시 일치해야 한다. `/bump-version` 스킬로 일괄 업데이트 가능.
+`release/{version}` 브랜치를 `main`으로 PR할 때 위 값들이 해당 버전과 반드시 일치해야 한다. `/bump-version` 스킬로 일괄 업데이트 가능.
 
 ## Snake Chain Rule
 


### PR DESCRIPTION
## Summary
- `/bump-version` 스킬의 업데이트 대상에 README.md 버전 뱃지 추가
- CLAUDE.md Version Management 섹션에 README.md 뱃지 항목 반영

## Test plan
- [ ] `/bump-version 1.1.0` 실행 시 README.md 뱃지도 함께 업데이트되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)