### PR TITLE
style: redesign page subtitles with mode colors

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -110,9 +110,9 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
       const yyyy = now.getUTCFullYear()
       const mm = String(now.getUTCMonth() + 1).padStart(2, '0')
       const dd = String(now.getUTCDate()).padStart(2, '0')
-      document.title = `Wor\u{1F517}dle ${yyyy}-${mm}-${dd}`
+      document.title = `Wor\u{1F517}dle Daily | ${yyyy}-${mm}-${dd}`
     } else if (isCustom) {
-      document.title = `Wor\u{1F517}dle Custom/${questioner}`
+      document.title = `Wor\u{1F517}dle Custom | ${questioner}`
     } else {
       document.title = `Wor\u{1F517}dle Practice`
     }
@@ -241,11 +241,15 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
         <div className="grow">
           <h1 className="text-xl font-bold">Wor&#x1F517;dle</h1>
           <p className="text-sm text-gray-500">
-            {isDaily
-              ? new Date().toLocaleDateString('en-CA')
-              : isCustom
-              ? `Custom/${questioner}`
-              : t('practice')}
+            {isDaily ? (
+              <>Daily | {new Date().toLocaleDateString('en-CA')}</>
+            ) : isCustom ? (
+              <>
+                <span className="text-green-500">Custom</span> | {questioner}
+              </>
+            ) : (
+              <span className="text-purple-500">{t('practice')}</span>
+            )}
           </p>
         </div>
         {translateElement}

--- a/src/components/pages/CreatePuzzlePage.tsx
+++ b/src/components/pages/CreatePuzzlePage.tsx
@@ -131,7 +131,7 @@ export const CreatePuzzlePage = () => {
       <div className="flex w-80 mx-auto items-center mb-8">
         <div className="grow">
           <h1 className="text-xl font-bold">Wor&#x1F517;dle</h1>
-          <p className="text-sm text-gray-500">{t('createPuzzle')}</p>
+          <p className="text-sm text-green-500">{t('createPuzzle')}</p>
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- 각 모드별 부제목 포맷 통일 및 색상 적용
- Daily: `Daily | YYYY-MM-DD`
- Practice: `Practice` (보라색, present 셀 색상)
- Create: `Create` (초록색, correct 셀 색상)
- Custom: `Custom` (초록색) `| {Questioner}`

## Test plan
- [x] Daily 모드: 부제목에 `Daily | 날짜` 표시 확인
- [x] Practice 모드: 보라색 `Practice` 표시 확인
- [x] Create 페이지: 초록색 `Create` 표시 확인
- [x] Custom 모드: 초록색 `Custom` + `| 출제자` 표시 확인
- [x] 탭 타이틀도 동일 포맷 반영 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)