### PR TITLE
test: add Playwright E2E tests

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,8 +18,26 @@ jobs:
       - name: Build
         run: npm run build
 
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install dependencies
+        run: npm install
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium webkit
+      - name: Run Playwright tests
+        run: npx playwright test
+      - name: Upload Playwright report
+        uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+
   deploy:
-    needs: test
+    needs: [test, e2e]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,7 @@ jobs:
         run: npm run build
 
   e2e:
+    if: (github.event_name == 'pull_request' && github.base_ref == 'main') || (github.event_name == 'push' && github.ref == 'refs/heads/main')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,9 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/e2e/chain-rule.spec.ts
+++ b/e2e/chain-rule.spec.ts
@@ -1,0 +1,138 @@
+import {
+  test,
+  expect,
+  customPuzzlePath,
+  submitWord,
+  getRowCells,
+  waitForGameReady,
+  screenshot,
+} from './fixtures/game.fixture'
+
+test.describe('Chain Rule', () => {
+  test.beforeEach(async ({ gamePage }) => {
+    await gamePage.goto(customPuzzlePath('crane'))
+    await waitForGameReady(gamePage)
+  })
+
+  test('first guess has no chain constraint (5 editable cells)', async ({ gamePage }) => {
+    const cells = getRowCells(gamePage, 0)
+    // All 5 cells should be empty and editable (no locked styling)
+    for (let i = 0; i < 5; i++) {
+      await expect(cells.nth(i)).not.toHaveClass(/bg-slate-100/)
+    }
+    await screenshot(gamePage, '01-first-row-no-chain')
+  })
+
+  test('second row locks last cell with chain letter', async ({ gamePage }) => {
+    // Guess 1: "stale" → last letter 'e'
+    await submitWord(gamePage, 'stale')
+    await screenshot(gamePage, '01-after-first-guess')
+
+    // Row 1 (second row): last cell should show chain letter 'e' with chain visual
+    const cells = getRowCells(gamePage, 1)
+    const lastCell = cells.nth(4)
+    await expect(lastCell).toContainText('e')
+    // Chain cell has chainTop styling (border-t-0)
+    await expect(lastCell).toHaveClass(/border-t-0/)
+    await screenshot(gamePage, '02-second-row-chain-locked-right')
+  })
+
+  test('third row locks first cell with chain letter', async ({ gamePage }) => {
+    // Guess 1: "stale" → chains 'e' to last pos of guess 2
+    await submitWord(gamePage, 'stale')
+    // Guess 2: type 4 chars, full guess ends with 'e': "blaze"
+    await submitWord(gamePage, 'blaz')
+    await screenshot(gamePage, '01-after-two-guesses')
+
+    // Row 2 (third row): first cell should show chain letter 'b' with chain visual
+    const cells = getRowCells(gamePage, 2)
+    const firstCell = cells.nth(0)
+    await expect(firstCell).toContainText('b')
+    await expect(firstCell).toHaveClass(/border-t-0/)
+    await screenshot(gamePage, '02-third-row-chain-locked-left')
+  })
+
+  test('chain alternates right-left-right pattern', async ({ gamePage }) => {
+    // Guess 1: "stale" → chain right (e)
+    await submitWord(gamePage, 'stale')
+
+    // Row 1: last cell has chain letter (right chain)
+    let cells = getRowCells(gamePage, 1)
+    await expect(cells.nth(4)).toContainText('e')
+    await expect(cells.nth(4)).toHaveClass(/border-t-0/)
+    await screenshot(gamePage, '01-chain-right-e')
+
+    // Guess 2: "blaze" → chain left (b)
+    await submitWord(gamePage, 'blaz')
+
+    // Row 2: first cell has chain letter (left chain)
+    cells = getRowCells(gamePage, 2)
+    await expect(cells.nth(0)).toContainText('b')
+    await expect(cells.nth(0)).toHaveClass(/border-t-0/)
+    await screenshot(gamePage, '02-chain-left-b')
+
+    // Guess 3: "boost" (starts with b) → chain right (t)
+    await submitWord(gamePage, 'oost')
+
+    // Row 3: last cell has chain letter (right chain)
+    cells = getRowCells(gamePage, 3)
+    await expect(cells.nth(4)).toContainText('t')
+    await expect(cells.nth(4)).toHaveClass(/border-t-0/)
+    await screenshot(gamePage, '03-chain-right-t')
+  })
+
+  test('ChainBridge renders between rows', async ({ gamePage }) => {
+    await submitWord(gamePage, 'stale')
+
+    // ChainBridge is the element between row 0 and row 1
+    // Bridge at index 0: nth-child(2) in the grid container
+    const bridge = gamePage.locator('.pb-6 > :nth-child(2)')
+    await expect(bridge).toBeVisible()
+
+    // The bridge should have a cell with chain border at the correct index
+    // Row 0→1 chains from right (index 4), so the 5th bridge cell has borders
+    const bridgeCell = bridge.locator('div').nth(4)
+    await expect(bridgeCell).toHaveClass(/border-l-2/)
+    await expect(bridgeCell).toHaveClass(/border-r-2/)
+    await screenshot(gamePage, '01-chain-bridge-between-rows')
+  })
+
+  test('chain letter inherits color from previous guess', async ({ gamePage }) => {
+    // Solution: "crane". Guess "stale" → 'e' is correct (position 4)
+    // Chain letter 'e' in row 1 should inherit green status
+    await submitWord(gamePage, 'stale')
+
+    const cells = getRowCells(gamePage, 1)
+    const lastCell = cells.nth(4)
+    // 'e' was correct in guess 1 → locked cell should show green
+    await expect(lastCell).toHaveClass(/bg-green-500/)
+    await screenshot(gamePage, '01-chain-letter-inherits-green')
+  })
+
+  test('dead end triggers early loss', async ({ gamePage }) => {
+    // Solution: "crane". We need to create a dead end.
+    // Guess 1: "stale" → chain 'e' right
+    await submitWord(gamePage, 'stale')
+    await screenshot(gamePage, '01-dead-end-guess1')
+    // Guess 2: "blaze" → chain 'b' left
+    await submitWord(gamePage, 'blaz')
+    await screenshot(gamePage, '02-dead-end-guess2')
+    // Guess 3: "boost" → chain 't' right
+    await submitWord(gamePage, 'oost')
+    await screenshot(gamePage, '03-dead-end-guess3')
+    // Guess 4: "first" → chain 'f' left
+    await submitWord(gamePage, 'firs')
+    await screenshot(gamePage, '04-dead-end-guess4')
+    // Guess 5: "flood" → chain 'd' right
+    // After guess 5, chain letter is 'd' at position 4.
+    // Solution[4] = 'e'. 'd' !== 'e' → dead end!
+    await submitWord(gamePage, 'lood')
+    await screenshot(gamePage, '05-dead-end-guess5-triggers-loss')
+
+    // Game should end with loss
+    await expect(
+      gamePage.locator('text=The word was crane')
+    ).toBeVisible({ timeout: 3000 })
+    await screenshot(gamePage, '06-dead-end-solution-revealed')
+  })
+})

--- a/e2e/fixtures/game.fixture.ts
+++ b/e2e/fixtures/game.fixture.ts
@@ -1,0 +1,84 @@
+import { test as base, expect, Page } from '@playwright/test'
+
+/** Encode a custom puzzle URL (mirrors src/lib/customPuzzle.ts) */
+export function encodeCustomPuzzle(word: string, questioner: string): string {
+  const text = `${word}_${questioner}`
+  const binary = Array.from(Buffer.from(text, 'utf-8'), (b) =>
+    String.fromCharCode(b)
+  ).join('')
+  let base64 = Buffer.from(binary, 'binary').toString('base64')
+  return base64.replace(/\+/g, '-').replace(/\//g, '_').replace(/=+$/, '')
+}
+
+/** Build a custom puzzle hash path */
+export function customPuzzlePath(word: string, questioner = 'test'): string {
+  return `/#/custom/${encodeCustomPuzzle(word, questioner)}`
+}
+
+type GameFixtures = {
+  gamePage: Page
+}
+
+/**
+ * Extended test with gamePage fixture.
+ * - Suppresses PatchNotes modal
+ * - Forces English locale
+ */
+export const test = base.extend<GameFixtures>({
+  gamePage: async ({ page }, use) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('seenPatchNotesVersion', '1.1.0')
+      localStorage.setItem('i18nextLng', 'en')
+      // Prevent Backspace from triggering browser back navigation (Safari/WebKit)
+      window.addEventListener('keydown', (e) => {
+        if (
+          e.code === 'Backspace' &&
+          !['INPUT', 'TEXTAREA'].includes(
+            (document.activeElement?.tagName ?? '')
+          )
+        ) {
+          e.preventDefault()
+        }
+      })
+    })
+    await use(page)
+  },
+})
+
+export { expect }
+
+/** Type a word using physical keyboard (e.code format) */
+export async function typeWord(page: Page, word: string) {
+  for (const ch of word) {
+    await page.keyboard.press(`Key${ch.toUpperCase()}`)
+    // Wait for React to process the state update and re-attach keyup listener
+    await page.waitForTimeout(50)
+  }
+}
+
+/** Submit a word via physical keyboard */
+export async function submitWord(page: Page, word: string) {
+  await typeWord(page, word)
+  await page.keyboard.press('Enter')
+  // Wait for React to process the submission
+  await page.waitForTimeout(100)
+}
+
+/** Get all cell elements in a specific row (0-indexed) */
+export function getRowCells(page: Page, rowIndex: number) {
+  // Each row is a flex div with 5 cells. Rows and bridges alternate.
+  // Row 0 = nth-child(1), Bridge 0 = nth-child(2), Row 1 = nth-child(3), etc.
+  const nthChild = rowIndex * 2 + 1
+  return page.locator(`.pb-6 > :nth-child(${nthChild}) > div`)
+}
+
+/** Wait for the game page to be fully loaded (keyboard visible) */
+export async function waitForGameReady(page: Page) {
+  await page.locator('button', { hasText: 'Enter' }).waitFor({ state: 'visible' })
+}
+
+/** Attach a named screenshot to the test report */
+export async function screenshot(page: Page, name: string) {
+  const body = await page.screenshot()
+  await test.info().attach(name, { body, contentType: 'image/png' })
+}

--- a/e2e/game-flow.spec.ts
+++ b/e2e/game-flow.spec.ts
@@ -1,0 +1,147 @@
+import {
+  test,
+  expect,
+  customPuzzlePath,
+  typeWord,
+  submitWord,
+  getRowCells,
+  waitForGameReady,
+  screenshot,
+} from './fixtures/game.fixture'
+
+test.describe('Game Flow', () => {
+  test.beforeEach(async ({ gamePage }) => {
+    await gamePage.goto(customPuzzlePath('crane'))
+    await waitForGameReady(gamePage)
+  })
+
+  test('win by typing correct word', async ({ gamePage }) => {
+    await screenshot(gamePage, '01-initial-board')
+    await submitWord(gamePage, 'crane')
+
+    // All 5 cells in row 0 should be green
+    const cells = getRowCells(gamePage, 0)
+    for (let i = 0; i < 5; i++) {
+      await expect(cells.nth(i)).toHaveClass(/bg-green-500/)
+    }
+    await screenshot(gamePage, '02-all-green-cells')
+
+    // Success alert appears
+    await expect(
+      gamePage.locator('.bg-green-200')
+    ).toBeVisible({ timeout: 3000 })
+    await screenshot(gamePage, '03-success-alert')
+
+    // Stats modal opens after alert
+    await expect(
+      gamePage.locator('text=Statistics')
+    ).toBeVisible({ timeout: 5000 })
+    await screenshot(gamePage, '04-stats-modal-after-win')
+  })
+
+  test('not enough letters alert', async ({ gamePage }) => {
+    await typeWord(gamePage, 'cra')
+    await screenshot(gamePage, '01-three-letters-typed')
+    await gamePage.keyboard.press('Enter')
+
+    await expect(
+      gamePage.locator('text=Not enough letters')
+    ).toBeVisible({ timeout: 3000 })
+    await screenshot(gamePage, '02-not-enough-letters-alert')
+  })
+
+  test('word not found alert', async ({ gamePage }) => {
+    await typeWord(gamePage, 'zzzzz')
+    await screenshot(gamePage, '01-invalid-word-typed')
+    await gamePage.keyboard.press('Enter')
+
+    await expect(
+      gamePage.locator('text=Word not found')
+    ).toBeVisible({ timeout: 3000 })
+    await screenshot(gamePage, '02-word-not-found-alert')
+  })
+
+  test('cell colors reflect guess accuracy', async ({ gamePage }) => {
+    // Solution is "crane" (c-r-a-n-e)
+    // Guess "trace": t=absent, r=correct, a=correct, c=present, e=correct
+    await submitWord(gamePage, 'trace')
+
+    const cells = getRowCells(gamePage, 0)
+    // t is NOT in "crane" → absent (slate)
+    await expect(cells.nth(0)).toHaveClass(/bg-slate-400/)
+    // r is at position 1 in "crane" → correct (green)
+    await expect(cells.nth(1)).toHaveClass(/bg-green-500/)
+    // a is at position 2 in "crane" → correct (green)
+    await expect(cells.nth(2)).toHaveClass(/bg-green-500/)
+    // c is in "crane" at position 0, not position 3 → present (purple)
+    await expect(cells.nth(3)).toHaveClass(/bg-purple-500/)
+    // e is at position 4 in "crane" → correct (green)
+    await expect(cells.nth(4)).toHaveClass(/bg-green-500/)
+
+    await screenshot(gamePage, '01-cell-colors-trace-vs-crane')
+  })
+
+  test('lose after 6 wrong guesses shows solution', async ({ gamePage }) => {
+    // Solution: "crane". Need 6 wrong guesses that respect chain rules.
+    // Guess 1: "stale" (no chain constraint)
+    await submitWord(gamePage, 'stale')
+    await screenshot(gamePage, '01-guess1-stale')
+    // Guess 2: chains from 'e' (last of guess 1) at last position → type 4 chars
+    // Full guess needs to end with 'e': type "blaz" → "blaze"
+    await submitWord(gamePage, 'blaz')
+    await screenshot(gamePage, '02-guess2-blaze')
+    // Guess 3: chains from 'b' (first of guess 2) at first position → type 4 chars
+    // Full guess starts with 'b': type "oost" → "boost"
+    await submitWord(gamePage, 'oost')
+    await screenshot(gamePage, '03-guess3-boost')
+    // Guess 4: chains from 't' (last of guess 3) at last position → type 4 chars
+    // Full guess ends with 't': type "firs" → "first"
+    await submitWord(gamePage, 'firs')
+    await screenshot(gamePage, '04-guess4-first')
+    // Guess 5: chains from 'f' (first of guess 4) at first position → type 4 chars
+    // Full guess starts with 'f': type "lood" → "flood"
+    await submitWord(gamePage, 'lood')
+    await screenshot(gamePage, '05-guess5-flood')
+
+    // After guess 5, check for dead end or guess 6
+    // Guess 6: chains from 'd' (last of guess 5) at last position → type 4 chars
+    // Full guess ends with 'd': type "moun" → "mound"
+    await submitWord(gamePage, 'moun')
+    await screenshot(gamePage, '06-guess6-mound')
+
+    // Solution alert should appear
+    await expect(
+      gamePage.locator('text=The word was crane')
+    ).toBeVisible({ timeout: 3000 })
+    await screenshot(gamePage, '07-solution-revealed')
+
+    // Stats modal opens
+    await expect(
+      gamePage.locator('text=Statistics')
+    ).toBeVisible({ timeout: 5000 })
+    await screenshot(gamePage, '08-stats-modal-after-loss')
+  })
+
+  test('game state persists on reload in daily mode', async ({ gamePage }) => {
+    // Switch to daily mode
+    await gamePage.goto('/')
+    await waitForGameReady(gamePage)
+
+    // Type and submit a guess
+    await submitWord(gamePage, 'stale')
+
+    // Verify the guess is shown
+    const cells = getRowCells(gamePage, 0)
+    await expect(cells.nth(0)).toHaveClass(/bg-(green|purple|slate)-/)
+    await screenshot(gamePage, '01-guess-before-reload')
+
+    // Reload
+    await gamePage.reload()
+    await waitForGameReady(gamePage)
+
+    // The guess should still be visible
+    const cellsAfter = getRowCells(gamePage, 0)
+    await expect(cellsAfter.nth(0)).toHaveClass(/bg-(green|purple|slate)-/)
+    await screenshot(gamePage, '02-guess-after-reload')
+  })
+})

--- a/e2e/keyboard-input.spec.ts
+++ b/e2e/keyboard-input.spec.ts
@@ -1,0 +1,114 @@
+import {
+  test,
+  expect,
+  customPuzzlePath,
+  typeWord,
+  getRowCells,
+  waitForGameReady,
+  screenshot,
+} from './fixtures/game.fixture'
+
+test.describe('Keyboard Input', () => {
+  test.beforeEach(async ({ gamePage }) => {
+    await gamePage.goto(customPuzzlePath('crane'))
+    await waitForGameReady(gamePage)
+  })
+
+  test('physical keyboard types letters into cells', async ({ gamePage }) => {
+    await typeWord(gamePage, 'house')
+
+    const cells = getRowCells(gamePage, 0)
+    await expect(cells.nth(0)).toContainText('h')
+    await expect(cells.nth(1)).toContainText('o')
+    await expect(cells.nth(2)).toContainText('u')
+    await expect(cells.nth(3)).toContainText('s')
+    await expect(cells.nth(4)).toContainText('e')
+    await screenshot(gamePage, '01-physical-keyboard-typed-house')
+  })
+
+  test('physical keyboard backspace removes last letter', async ({ gamePage }) => {
+    await typeWord(gamePage, 'hou')
+    await screenshot(gamePage, '01-before-backspace')
+    await gamePage.keyboard.press('Backspace')
+
+    const cells = getRowCells(gamePage, 0)
+    await expect(cells.nth(0)).toContainText('h')
+    await expect(cells.nth(1)).toContainText('o')
+    await expect(cells.nth(2)).toHaveText('')
+    await screenshot(gamePage, '02-after-backspace')
+  })
+
+  test('physical keyboard enter submits guess', async ({ gamePage }) => {
+    await typeWord(gamePage, 'stale')
+    await screenshot(gamePage, '01-before-enter')
+    await gamePage.keyboard.press('Enter')
+
+    // After submit, row 0 should be completed (cells have status colors)
+    const cells = getRowCells(gamePage, 0)
+    const firstCell = cells.nth(0)
+    await expect(firstCell).toHaveClass(/bg-(green|purple|slate)-/)
+    await screenshot(gamePage, '02-after-submit-with-colors')
+  })
+
+  test('on-screen keyboard types letters', async ({ gamePage }) => {
+    // Click letter buttons on the on-screen keyboard
+    for (const ch of 'house') {
+      await gamePage.locator(`button:text-is("${ch}")`).click()
+    }
+
+    const cells = getRowCells(gamePage, 0)
+    await expect(cells.nth(0)).toContainText('h')
+    await expect(cells.nth(4)).toContainText('e')
+    await screenshot(gamePage, '01-on-screen-keyboard-typed-house')
+  })
+
+  test('on-screen Delete removes last letter', async ({ gamePage }) => {
+    for (const ch of 'hou') {
+      await gamePage.locator(`button:text-is("${ch}")`).click()
+    }
+    await screenshot(gamePage, '01-before-delete')
+    await gamePage.locator('button', { hasText: 'Delete' }).click()
+
+    const cells = getRowCells(gamePage, 0)
+    await expect(cells.nth(2)).toHaveText('')
+    await screenshot(gamePage, '02-after-delete')
+  })
+
+  test('on-screen Enter submits guess', async ({ gamePage }) => {
+    for (const ch of 'stale') {
+      await gamePage.locator(`button:text-is("${ch}")`).click()
+    }
+    await screenshot(gamePage, '01-on-screen-before-enter')
+    await gamePage.locator('button', { hasText: 'Enter' }).click()
+
+    const cells = getRowCells(gamePage, 0)
+    await expect(cells.nth(0)).toHaveClass(/bg-(green|purple|slate)-/)
+    await screenshot(gamePage, '02-on-screen-after-submit')
+  })
+
+  test('keyboard colors update after guess', async ({ gamePage }) => {
+    // "crane" is the solution → all letters correct
+    await typeWord(gamePage, 'crane')
+    await gamePage.keyboard.press('Enter')
+
+    // The 'c' key should turn green
+    const cKey = gamePage.locator('button:text-is("c")')
+    await expect(cKey).toHaveClass(/bg-green-500/)
+    await screenshot(gamePage, '01-keyboard-keys-turned-green')
+  })
+
+  test('input blocked after game won', async ({ gamePage }) => {
+    // Win the game
+    await typeWord(gamePage, 'crane')
+    await gamePage.keyboard.press('Enter')
+    await screenshot(gamePage, '01-game-won')
+
+    // Try to type more letters
+    await typeWord(gamePage, 'house')
+
+    // Row 1 (second row) should still be empty
+    const cells = getRowCells(gamePage, 1)
+    await expect(cells.nth(0)).toHaveText('')
+    await screenshot(gamePage, '02-input-blocked-after-win')
+  })
+})

--- a/e2e/mobile-responsive.spec.ts
+++ b/e2e/mobile-responsive.spec.ts
@@ -1,0 +1,121 @@
+import {
+  test,
+  expect,
+  customPuzzlePath,
+  getRowCells,
+  waitForGameReady,
+  screenshot,
+} from './fixtures/game.fixture'
+
+// Only run on mobile projects
+test.describe('Mobile Responsive', () => {
+  test('grid renders within mobile viewport', async ({ gamePage }, testInfo) => {
+    test.skip(!testInfo.project.name.startsWith('mobile'), 'Mobile-only')
+    await gamePage.goto(customPuzzlePath('crane'))
+    await waitForGameReady(gamePage)
+
+    const cells = getRowCells(gamePage, 0)
+    for (let i = 0; i < 5; i++) {
+      await expect(cells.nth(i)).toBeVisible()
+    }
+
+    const gridContainer = gamePage.locator('.pb-6')
+    const box = await gridContainer.boundingBox()
+    expect(box).toBeTruthy()
+
+    const viewport = gamePage.viewportSize()!
+    expect(box!.x).toBeGreaterThanOrEqual(0)
+    expect(box!.x + box!.width).toBeLessThanOrEqual(viewport.width)
+    await screenshot(gamePage, '01-mobile-grid-in-viewport')
+  })
+
+  test('keyboard renders all keys and is tappable', async ({ gamePage }, testInfo) => {
+    test.skip(!testInfo.project.name.startsWith('mobile'), 'Mobile-only')
+    await gamePage.goto(customPuzzlePath('crane'))
+    await waitForGameReady(gamePage)
+    await screenshot(gamePage, '01-mobile-keyboard-initial')
+
+    const letterKeys = 'qwertyuiopasdfghjklzxcvbnm'
+    for (const ch of letterKeys) {
+      await expect(
+        gamePage.locator(`button:text-is("${ch}")`)
+      ).toBeVisible()
+    }
+    await expect(
+      gamePage.locator('button', { hasText: 'Enter' })
+    ).toBeVisible()
+    await expect(
+      gamePage.locator('button', { hasText: 'Delete' })
+    ).toBeVisible()
+
+    // Tap some keys and verify input
+    await gamePage.locator('button:text-is("h")').tap()
+    await gamePage.locator('button:text-is("o")').tap()
+    await gamePage.locator('button:text-is("u")').tap()
+    await gamePage.locator('button:text-is("s")').tap()
+    await gamePage.locator('button:text-is("e")').tap()
+
+    const cells = getRowCells(gamePage, 0)
+    await expect(cells.nth(0)).toContainText('h')
+    await expect(cells.nth(4)).toContainText('e')
+    await screenshot(gamePage, '02-mobile-keyboard-after-tap')
+  })
+
+  test('modals render within mobile viewport', async ({ gamePage }, testInfo) => {
+    test.skip(!testInfo.project.name.startsWith('mobile'), 'Mobile-only')
+    await gamePage.goto('/')
+    await waitForGameReady(gamePage)
+
+    // Open info modal
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(1).click()
+    await expect(gamePage.locator('text=How to play')).toBeVisible()
+
+    // Modal panel should not overflow horizontally
+    const modalPanel = gamePage.locator('.inline-block.align-bottom')
+    const box = await modalPanel.boundingBox()
+    expect(box).toBeTruthy()
+
+    const viewport = gamePage.viewportSize()!
+    expect(box!.x).toBeGreaterThanOrEqual(0)
+    expect(box!.x + box!.width).toBeLessThanOrEqual(viewport.width + 1)
+    await screenshot(gamePage, '01-mobile-modal-within-viewport')
+  })
+
+  test('header icons are accessible on mobile', async ({ gamePage }, testInfo) => {
+    test.skip(!testInfo.project.name.startsWith('mobile'), 'Mobile-only')
+    await gamePage.goto('/')
+    await waitForGameReady(gamePage)
+
+    const headerIcons = gamePage.locator('.flex.w-80 svg.cursor-pointer')
+    const count = await headerIcons.count()
+
+    for (let i = 0; i < count; i++) {
+      const icon = headerIcons.nth(i)
+      await expect(icon).toBeVisible()
+      const box = await icon.boundingBox()
+      expect(box).toBeTruthy()
+      expect(box!.width).toBeGreaterThanOrEqual(20)
+      expect(box!.height).toBeGreaterThanOrEqual(20)
+    }
+    await screenshot(gamePage, '01-mobile-header-icons')
+  })
+
+  test('bottom navigation buttons are visible and tappable', async ({ gamePage }, testInfo) => {
+    test.skip(!testInfo.project.name.startsWith('mobile'), 'Mobile-only')
+    await gamePage.goto('/')
+    await waitForGameReady(gamePage)
+
+    const aboutBtn = gamePage.locator('button', { hasText: 'About this game' })
+    const practiceLink = gamePage.locator('a', { hasText: 'Practice' })
+    const createLink = gamePage.locator('a', { hasText: 'Create' })
+
+    await expect(aboutBtn).toBeVisible()
+    await expect(practiceLink).toBeVisible()
+    await expect(createLink).toBeVisible()
+    await screenshot(gamePage, '01-mobile-bottom-nav')
+
+    await practiceLink.tap()
+    await expect(gamePage).toHaveURL(/\/#\/practice/)
+    await screenshot(gamePage, '02-mobile-navigated-to-practice')
+  })
+})

--- a/e2e/modals.spec.ts
+++ b/e2e/modals.spec.ts
@@ -1,0 +1,131 @@
+import { test, expect, waitForGameReady, screenshot } from './fixtures/game.fixture'
+import { test as baseTest } from '@playwright/test'
+
+test.describe('Modals', () => {
+  test.beforeEach(async ({ gamePage }) => {
+    await gamePage.goto('/')
+    await waitForGameReady(gamePage)
+  })
+
+  test('info modal opens and closes', async ({ gamePage }) => {
+    // Click info icon (InformationCircleIcon)
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(1).click()
+
+    await expect(gamePage.locator('text=How to play')).toBeVisible()
+    await expect(gamePage.locator('text=Chain Rule')).toBeVisible()
+    await screenshot(gamePage, '01-info-modal-open')
+
+    // Close via X button
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
+    await expect(gamePage.locator('text=How to play')).not.toBeVisible()
+    await screenshot(gamePage, '02-info-modal-closed')
+  })
+
+  test('stats modal opens and closes', async ({ gamePage }) => {
+    // Click stats icon (ChartBarIcon) — 3rd icon in daily mode
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
+
+    await expect(gamePage.locator('text=Statistics')).toBeVisible()
+    await expect(gamePage.locator('text=Total tries')).toBeVisible()
+    await expect(gamePage.locator('text=Success rate')).toBeVisible()
+    await screenshot(gamePage, '01-stats-modal-open')
+
+    // Close
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
+    await expect(gamePage.locator('text=Statistics')).not.toBeVisible()
+  })
+
+  test('settings modal with uppercase toggle', async ({ gamePage }) => {
+    // Click settings icon (CogIcon) — 4th icon
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(3).click()
+
+    await expect(gamePage.locator('text=Settings')).toBeVisible()
+    await expect(gamePage.locator('text=Uppercase Letters')).toBeVisible()
+    await screenshot(gamePage, '01-settings-modal-open')
+
+    // Toggle uppercase on
+    const toggle = gamePage.locator('button[role="switch"]')
+    await toggle.click()
+    await screenshot(gamePage, '02-uppercase-toggle-on')
+
+    // Close settings
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
+
+    // Grid and keyboard should have uppercase class
+    await expect(gamePage.locator('.uppercase')).toBeVisible()
+    await screenshot(gamePage, '03-uppercase-applied-to-page')
+
+    // Reopen settings and toggle off
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(3).click()
+    await gamePage.locator('button[role="switch"]').click()
+    await screenshot(gamePage, '04-uppercase-toggle-off')
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
+
+    // Uppercase class should be gone
+    await expect(gamePage.locator('.uppercase')).not.toBeVisible()
+    await screenshot(gamePage, '05-uppercase-removed-from-page')
+  })
+
+  test('donate modal opens and closes', async ({ gamePage }) => {
+    // Click donate icon (CurrencyDollarIcon) — 5th icon
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(4).click()
+
+    await expect(gamePage.locator('text=Donate')).toBeVisible()
+    await screenshot(gamePage, '01-donate-modal-open')
+
+    // Close
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
+    await expect(gamePage.locator('text=Donate')).not.toBeVisible()
+  })
+
+  test('about modal opens via bottom button', async ({ gamePage }) => {
+    await gamePage.locator('button', { hasText: 'About this game' }).click()
+
+    await expect(gamePage.locator('h3:has-text("About")')).toBeVisible()
+    await screenshot(gamePage, '01-about-modal-open')
+
+    // Close
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
+  })
+
+  test('modal closes on Escape key', async ({ gamePage }) => {
+    // Open info modal
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(1).click()
+    await expect(gamePage.locator('text=How to play')).toBeVisible()
+    await screenshot(gamePage, '01-modal-open-before-escape')
+
+    // Press Escape to close (HeadlessUI Dialog handles this natively)
+    await gamePage.keyboard.press('Escape')
+    await expect(gamePage.locator('text=How to play')).not.toBeVisible()
+    await screenshot(gamePage, '02-modal-closed-after-escape')
+  })
+})
+
+// PatchNotes modal test — without the gamePage fixture (no localStorage suppression)
+baseTest.describe('PatchNotes Modal', () => {
+  baseTest('shows on first visit and remembers dismissal', async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('i18nextLng', 'en')
+      // Do NOT set seenPatchNotesVersion — simulate first visit
+    })
+
+    await page.goto('/')
+    await page.locator('button', { hasText: 'Enter' }).waitFor({ state: 'visible' })
+
+    // PatchNotes modal should be open
+    await expect(page.locator("text=What's New")).toBeVisible({ timeout: 5000 })
+    const body1 = await page.screenshot()
+    await baseTest.info().attach('01-patch-notes-first-visit', { body: body1, contentType: 'image/png' })
+
+    // Close it
+    await page.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
+    await expect(page.locator("text=What's New")).not.toBeVisible()
+
+    // Reload — should NOT reappear
+    await page.reload()
+    await page.locator('button', { hasText: 'Enter' }).waitFor({ state: 'visible' })
+    await expect(page.locator("text=What's New")).not.toBeVisible()
+    const body2 = await page.screenshot()
+    await baseTest.info().attach('02-patch-notes-dismissed-after-reload', { body: body2, contentType: 'image/png' })
+  })
+})

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,0 +1,100 @@
+import { test, expect, customPuzzlePath, waitForGameReady, screenshot } from './fixtures/game.fixture'
+
+test.describe('Navigation', () => {
+  test('daily page renders with date subtitle', async ({ gamePage }) => {
+    await gamePage.goto('/')
+    await waitForGameReady(gamePage)
+
+    await expect(gamePage.locator('h1')).toContainText('Wor')
+    await expect(gamePage.locator('h1')).toContainText('dle')
+    // Date in yyyy-mm-dd format
+    await expect(gamePage.locator('text=/\\d{4}-\\d{2}-\\d{2}/')).toBeVisible()
+    await screenshot(gamePage, '01-daily-page')
+  })
+
+  test('practice page shows Practice subtitle', async ({ gamePage }) => {
+    await gamePage.goto('/#/practice')
+    await waitForGameReady(gamePage)
+
+    await expect(gamePage.locator('text=Practice')).toBeVisible()
+    await screenshot(gamePage, '01-practice-page')
+  })
+
+  test('navigate from daily to practice via bottom button', async ({ gamePage }) => {
+    await gamePage.goto('/')
+    await waitForGameReady(gamePage)
+    await screenshot(gamePage, '01-daily-before-navigate')
+
+    await gamePage.locator('a', { hasText: 'Practice' }).click()
+    await expect(gamePage).toHaveURL(/\/#\/practice/)
+    await expect(gamePage.locator('text=Practice')).toBeVisible()
+    await screenshot(gamePage, '02-practice-after-navigate')
+  })
+
+  test('navigate from practice to daily via bottom button', async ({ gamePage }) => {
+    await gamePage.goto('/#/practice')
+    await waitForGameReady(gamePage)
+    await screenshot(gamePage, '01-practice-before-navigate')
+
+    await gamePage.locator('a', { hasText: 'Daily' }).click()
+    await expect(gamePage).toHaveURL(/\/#\/$/)
+    await screenshot(gamePage, '02-daily-after-navigate')
+  })
+
+  test('create puzzle page renders', async ({ gamePage }) => {
+    await gamePage.goto('/#/create')
+    await waitForGameReady(gamePage)
+
+    await expect(gamePage.locator('p.text-green-500', { hasText: 'Create' })).toBeVisible()
+    await expect(gamePage.locator('input[placeholder="Enter your name"]')).toBeVisible()
+    await screenshot(gamePage, '01-create-puzzle-page')
+  })
+
+  test('navigate from daily to create via bottom button', async ({ gamePage }) => {
+    await gamePage.goto('/')
+    await waitForGameReady(gamePage)
+
+    await gamePage.locator('a', { hasText: 'Create' }).click()
+    await expect(gamePage).toHaveURL(/\/#\/create/)
+    await screenshot(gamePage, '01-create-page-after-navigate')
+  })
+
+  test('custom puzzle page shows questioner name', async ({ gamePage }) => {
+    await gamePage.goto(customPuzzlePath('crane', 'Alice'))
+    await waitForGameReady(gamePage)
+
+    await expect(gamePage.locator('text=Custom')).toBeVisible()
+    await expect(gamePage.locator('text=Alice')).toBeVisible()
+    await screenshot(gamePage, '01-custom-puzzle-alice')
+  })
+
+  test('invalid custom puzzle redirects to daily', async ({ gamePage }) => {
+    await gamePage.goto('/#/custom/invalidcode')
+    await waitForGameReady(gamePage)
+
+    // Should redirect to daily page
+    await expect(gamePage).toHaveURL(/\/#\/$/)
+    await screenshot(gamePage, '01-redirected-to-daily')
+  })
+
+  test('stats icon visible on daily, hidden on practice', async ({ gamePage }) => {
+    // Daily: stats icon visible
+    await gamePage.goto('/')
+    await waitForGameReady(gamePage)
+    const statsIcon = gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2)
+    await expect(statsIcon).toBeVisible()
+    await screenshot(gamePage, '01-daily-with-stats-icon')
+
+    // Practice: stats icon hidden (only 4 icons instead of 5)
+    await gamePage.goto('/#/practice')
+    await waitForGameReady(gamePage)
+    // In practice mode, ChartBarIcon is not rendered
+    // Count cursor-pointer SVG icons in header
+    const headerIcons = gamePage.locator('.flex.w-80 svg.cursor-pointer')
+    const count = await headerIcons.count()
+    // Daily has: translate, info, stats, settings, donate (5)
+    // Practice has: translate, info, settings, donate (4)
+    expect(count).toBeLessThan(5)
+    await screenshot(gamePage, '02-practice-without-stats-icon')
+  })
+})

--- a/e2e/tsconfig.json
+++ b/e2e/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2020",
+    "module": "esnext",
+    "moduleResolution": "node",
+    "strict": true,
+    "esModuleInterop": true,
+    "noEmit": true
+  },
+  "include": ["."]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,6 +33,7 @@
                 "web-vitals": "^2.1.3"
             },
             "devDependencies": {
+                "@playwright/test": "^1.58.2",
                 "@types/react-router-dom": "^5.3.3",
                 "autoprefixer": "^10.4.2",
                 "gh-pages": "^3.2.3",
@@ -2798,6 +2799,21 @@
             },
             "engines": {
                 "node": ">= 8"
+            }
+        },
+        "node_modules/@playwright/test": {
+            "version": "1.58.2",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+            "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+            "dev": true,
+            "dependencies": {
+                "playwright": "1.58.2"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
             }
         },
         "node_modules/@pmmmwh/react-refresh-webpack-plugin": {
@@ -12377,6 +12393,36 @@
                 "node": ">=4"
             }
         },
+        "node_modules/playwright": {
+            "version": "1.58.2",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+            "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+            "dev": true,
+            "dependencies": {
+                "playwright-core": "1.58.2"
+            },
+            "bin": {
+                "playwright": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            },
+            "optionalDependencies": {
+                "fsevents": "2.3.2"
+            }
+        },
+        "node_modules/playwright-core": {
+            "version": "1.58.2",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+            "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+            "dev": true,
+            "bin": {
+                "playwright-core": "cli.js"
+            },
+            "engines": {
+                "node": ">=18"
+            }
+        },
         "node_modules/portfinder": {
             "version": "1.0.28",
             "resolved": "https://registry.npmjs.org/portfinder/-/portfinder-1.0.28.tgz",
@@ -18828,6 +18874,15 @@
             "requires": {
                 "@nodelib/fs.scandir": "2.1.5",
                 "fastq": "^1.6.0"
+            }
+        },
+        "@playwright/test": {
+            "version": "1.58.2",
+            "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.58.2.tgz",
+            "integrity": "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA==",
+            "dev": true,
+            "requires": {
+                "playwright": "1.58.2"
             }
         },
         "@pmmmwh/react-refresh-webpack-plugin": {
@@ -25821,6 +25876,22 @@
                     "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
                 }
             }
+        },
+        "playwright": {
+            "version": "1.58.2",
+            "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.58.2.tgz",
+            "integrity": "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A==",
+            "dev": true,
+            "requires": {
+                "fsevents": "2.3.2",
+                "playwright-core": "1.58.2"
+            }
+        },
+        "playwright-core": {
+            "version": "1.58.2",
+            "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.58.2.tgz",
+            "integrity": "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg==",
+            "dev": true
         },
         "portfinder": {
             "version": "1.0.28",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,11 @@
         "build": "react-scripts build",
         "test": "react-scripts test",
         "eject": "react-scripts eject",
-        "prepare": "husky install"
+        "prepare": "husky install",
+        "test:e2e": "playwright test",
+        "test:e2e:ui": "playwright test --ui",
+        "test:e2e:headed": "playwright test --headed",
+        "test:e2e:mobile": "playwright test --project=mobile-safari --project=mobile-chrome"
     },
     "eslintConfig": {
         "extends": [
@@ -58,6 +62,7 @@
         ]
     },
     "devDependencies": {
+        "@playwright/test": "^1.58.2",
         "@types/react-router-dom": "^5.3.3",
         "autoprefixer": "^10.4.2",
         "gh-pages": "^3.2.3",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -35,7 +35,7 @@ export default defineConfig({
   ],
 
   webServer: {
-    command: 'npm start',
+    command: 'npm run build && npx serve -s build -l 3000',
     url: 'http://localhost:3000',
     reuseExistingServer: !process.env.CI,
     timeout: 120_000,

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: process.env.CI ? 'github' : 'html',
+  timeout: 30_000,
+
+  use: {
+    baseURL: 'http://localhost:3000',
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'webkit',
+      use: { ...devices['Desktop Safari'] },
+    },
+    {
+      name: 'mobile-safari',
+      use: { ...devices['iPhone 13'] },
+    },
+    {
+      name: 'mobile-chrome',
+      use: { ...devices['Pixel 5'] },
+    },
+  ],
+
+  webServer: {
+    command: 'npm start',
+    url: 'http://localhost:3000',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})


### PR DESCRIPTION
## Summary
- Playwright E2E 테스트 도입 (42개 테스트, 4개 브라우저 프로젝트)
- Desktop Chromium, Desktop WebKit, iPhone 13 (mobile-safari), Pixel 5 (mobile-chrome)
- 테스트 범위: game-flow, chain-rule, keyboard-input, modals, navigation, mobile-responsive
- 주요 장면마다 스크린샷 첨부 (~61장, HTML 리포트에서 확인 가능)
- CI에 e2e job 추가 + main 브랜치 Ruleset에 `test`, `e2e` 필수 체크 설정

## Test plan
- [x] 로컬 전체 테스트 통과 (168 tests: 158 passed, 10 skipped)
- [x] CI에서 e2e job 통과 확인
- [x] Playwright HTML 리포트에서 스크린샷 확인 (`npx playwright show-report`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)