### PR TITLE
feat: add KakaoPay payment link to donate modal

### DIFF
--- a/e2e/fixtures/game.fixture.ts
+++ b/e2e/fixtures/game.fixture.ts
@@ -79,6 +79,8 @@ export async function waitForGameReady(page: Page) {
 
 /** Attach a named screenshot to the test report */
 export async function screenshot(page: Page, name: string) {
+  // Wait for modal transition animations to complete
+  await page.waitForTimeout(300)
   const body = await page.screenshot()
   await test.info().attach(name, { body, contentType: 'image/png' })
 }

--- a/e2e/modals.spec.ts
+++ b/e2e/modals.spec.ts
@@ -71,6 +71,14 @@ test.describe('Modals', () => {
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(4).click()
 
     await expect(gamePage.locator('text=Donate')).toBeVisible()
+
+    // QR image and payment link button should both be visible
+    await expect(gamePage.locator('img[alt="KakaoPay QR"]')).toBeVisible()
+    await expect(gamePage.locator('a:has-text("Pay with KakaoPay")')).toBeVisible()
+    await expect(gamePage.locator('a:has-text("Pay with KakaoPay")')).toHaveAttribute(
+      'href',
+      'https://qr.kakaopay.com/FE0rjwVWj41a00262'
+    )
     await screenshot(gamePage, '01-donate-modal-open')
 
     // Close

--- a/public/locales/en/translation.json
+++ b/public/locales/en/translation.json
@@ -29,6 +29,7 @@
     "uppercaseLabel": "Uppercase Letters",
     "donate": "Donate",
     "donateMonsterDrink": "Buy developer a monster drink!",
+    "donateKakaoPay": "Pay with KakaoPay",
     "practice": "Practice",
     "daily": "Daily",
     "createPuzzleNav": "Create",

--- a/public/locales/es/translation.json
+++ b/public/locales/es/translation.json
@@ -25,6 +25,7 @@
   "uppercaseLabel": "Letras mayúsculas",
   "donate": "Donar",
   "donateMonsterDrink": "Buy developer a monster drink!",
+  "donateKakaoPay": "Pagar con KakaoPay",
   "practice": "Práctica",
   "daily": "Diario",
   "createPuzzleNav": "Crear",

--- a/public/locales/ja/translation.json
+++ b/public/locales/ja/translation.json
@@ -29,6 +29,7 @@
     "uppercaseLabel": "大文字表示",
     "donate": "寄付",
     "donateMonsterDrink": "開発者にドリンクを一杯おごってください！",
+    "donateKakaoPay": "KakaoPayで支払う",
     "practice": "練習",
     "daily": "今日の問題",
     "createPuzzleNav": "出題",

--- a/public/locales/ko/translation.json
+++ b/public/locales/ko/translation.json
@@ -29,6 +29,7 @@
     "uppercaseLabel": "대문자 표시",
     "donate": "후원",
     "donateMonsterDrink": "개발자에게 음료수 한 잔 사주세요!",
+    "donateKakaoPay": "카카오페이로 결제",
     "practice": "연습",
     "daily": "오늘의 문제",
     "createPuzzleNav": "출제",

--- a/public/locales/sw/translation.json
+++ b/public/locales/sw/translation.json
@@ -25,6 +25,7 @@
   "uppercaseLabel": "Herufi kubwa",
   "donate": "Changia",
   "donateMonsterDrink": "Buy developer a monster drink!",
+  "donateKakaoPay": "Lipa na KakaoPay",
   "practice": "Mazoezi",
   "daily": "Kila siku",
   "createPuzzleNav": "Unda",

--- a/public/locales/zh/translation.json
+++ b/public/locales/zh/translation.json
@@ -25,6 +25,7 @@
   "uppercaseLabel": "大寫字母",
   "donate": "捐贈",
   "donateMonsterDrink": "Buy developer a monster drink!",
+  "donateKakaoPay": "使用KakaoPay支付",
   "practice": "練習",
   "daily": "每日挑戰",
   "createPuzzleNav": "出题",

--- a/src/components/modals/DonateModal.tsx
+++ b/src/components/modals/DonateModal.tsx
@@ -1,6 +1,7 @@
 import { useState } from 'react'
 import { BaseModal } from './BaseModal'
 import { useTranslation } from 'react-i18next'
+import { KAKAOPAY_PAYMENT_URL } from '../../constants/config'
 
 type Tab = {
   id: string
@@ -49,6 +50,14 @@ export const DonateModal = ({ isOpen, handleClose }: Props) => {
             alt="KakaoPay QR"
             className="w-48 mb-3"
           />
+          <a
+            href={KAKAOPAY_PAYMENT_URL}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center px-6 py-3 mb-3 text-base font-medium rounded-md text-gray-900 bg-yellow-400 hover:bg-yellow-500 shadow-sm focus:outline-none"
+          >
+            {t('donateKakaoPay')}
+          </a>
           <p className="text-sm font-medium text-gray-700">
             {t('donateMonsterDrink')}
           </p>

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -1,5 +1,8 @@
 export const PATCH_NOTES_VERSION = '1.1.0'
 
+export const KAKAOPAY_PAYMENT_URL =
+  'https://qr.kakaopay.com/FE0rjwVWj41a00262'
+
 export const CONFIG = {
   tries: 6,
   language: 'English',


### PR DESCRIPTION
## Summary
- 후원 모달에 QR 코드와 함께 KakaoPay 직접 결제 링크 버튼 추가
- 모바일에서도 QR 스캔 없이 바로 후원 가능
- 6개 언어 번역 키(`donateKakaoPay`) 추가
- E2E 테스트에 QR 이미지 및 결제 링크 검증 추가, 스크린샷 애니메이션 대기 개선

Closes #42

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] Playwright E2E 테스트 4개 브라우저 통과 (chromium, webkit, mobile-chrome, mobile-safari)
- [x] 모바일 실기기에서 결제 링크 버튼 표시 확인
- [x] 결제 링크 클릭 시 KakaoPay 송금 페이지 이동 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)