### PR TITLE
fix: use heading locator for donate modal E2E test

### DIFF
--- a/e2e/modals.spec.ts
+++ b/e2e/modals.spec.ts
@@ -70,7 +70,7 @@ test.describe('Modals', () => {
     // Click donate icon (CurrencyDollarIcon) — 5th icon
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(4).click()
 
-    await expect(gamePage.locator('text=Donate')).toBeVisible()
+    await expect(gamePage.locator('h3:has-text("Donate")')).toBeVisible()
 
     // KakaoPay tab (default): QR image and payment link button
     await expect(gamePage.locator('img[alt="KakaoPay QR"]')).toBeVisible()
@@ -89,7 +89,7 @@ test.describe('Modals', () => {
 
     // Close
     await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
-    await expect(gamePage.locator('text=Donate')).not.toBeVisible()
+    await expect(gamePage.locator('h3:has-text("Donate")')).not.toBeVisible()
   })
 
   test('about modal opens via bottom button', async ({ gamePage }) => {


### PR DESCRIPTION
## Summary
- "Donate via KakaoPay" 버튼 텍스트에 "Donate"가 포함되어 `text=Donate` locator가 2개 요소에 매칭되는 strict mode 오류 수정
- `text=Donate` → `h3:has-text("Donate")`로 변경하여 모달 제목만 매칭

## Test plan
- [ ] `npx playwright test e2e/modals.spec.ts --grep "donate"` 4개 브라우저 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)