### PR TITLE
feat: add country flag emojis to language selector (#45)

### DIFF
--- a/e2e/modals.spec.ts
+++ b/e2e/modals.spec.ts
@@ -92,6 +92,45 @@ test.describe('Modals', () => {
     await expect(gamePage.locator('h3:has-text("Donate")')).not.toBeVisible()
   })
 
+  test('translate modal opens with flag emojis', async ({ gamePage }) => {
+    // Click translate icon (first icon)
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(0).click()
+
+    await expect(gamePage.locator('h3:has-text("language")')).toBeVisible()
+    await expect(gamePage.locator('text=English')).toBeVisible()
+    await screenshot(gamePage, '01-translate-modal-open')
+
+    // Close
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
+    await expect(gamePage.locator('h3:has-text("language")')).not.toBeVisible()
+  })
+
+  test('translate modal title does not overlap close button', async ({ gamePage }, testInfo) => {
+    test.skip(!testInfo.project.name.startsWith('mobile'), 'Mobile-only')
+
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(0).click()
+    await gamePage.waitForTimeout(300)
+
+    // Measure actual text width using Range API
+    const titleTextRight = await gamePage.evaluate(() => {
+      const h3 = document.querySelector('h3')
+      if (!h3) return null
+      const range = document.createRange()
+      range.selectNodeContents(h3)
+      return range.getBoundingClientRect().right
+    })
+    expect(titleTextRight).toBeTruthy()
+
+    const closeBtn = gamePage.locator('.inline-block.align-bottom svg.h-6.w-6.cursor-pointer')
+    const closeBtnBox = await closeBtn.boundingBox()
+    expect(closeBtnBox).toBeTruthy()
+
+    await screenshot(gamePage, '01-translate-modal-no-overlap')
+
+    const overlap = titleTextRight! - closeBtnBox!.x
+    expect(overlap, `Title overlaps close button by ${overlap}px`).toBeLessThanOrEqual(0)
+  })
+
   test('about modal opens via bottom button', async ({ gamePage }) => {
     await gamePage.locator('button', { hasText: 'About this game' }).click()
 

--- a/src/components/modals/BaseModal.tsx
+++ b/src/components/modals/BaseModal.tsx
@@ -59,7 +59,7 @@ export const BaseModal = ({ title, children, isOpen, handleClose }: Props) => {
                 <div className="text-center">
                   <Dialog.Title
                     as="h3"
-                    className="text-lg leading-6 font-medium text-gray-900"
+                    className="text-lg leading-6 font-medium text-gray-900 pr-8"
                   >
                     {title}
                   </Dialog.Title>

--- a/src/components/modals/TranslateModal.tsx
+++ b/src/components/modals/TranslateModal.tsx
@@ -8,6 +8,15 @@ type Props = {
   handleClose: () => void
 }
 
+const langFlags: Record<string, string> = {
+  en: '🇺🇸🇬🇧',
+  ko: '🇰🇷',
+  ja: '🇯🇵',
+  es: '🇪🇸',
+  sw: '🇹🇿🇰🇪',
+  zh: '🇨🇳',
+}
+
 export const TranslateModal = ({ isOpen, handleClose }: Props) => {
   const { t, i18n } = useTranslation()
   const onChangeValue = (event: any) => {
@@ -18,7 +27,7 @@ export const TranslateModal = ({ isOpen, handleClose }: Props) => {
   const createOption = (code: string, text: string) => {
     return (
       <div key={code}>
-        <label>{text}</label>
+        <label>{langFlags[code]} {text}</label>
         <input
           className="m-2"
           checked={

--- a/src/components/modals/TranslateModal.tsx
+++ b/src/components/modals/TranslateModal.tsx
@@ -49,7 +49,7 @@ export const TranslateModal = ({ isOpen, handleClose }: Props) => {
       handleClose={handleClose}
     >
       <div
-        className="py-8 max-w-7xl mx-auto sm:px-6 lg:px-8"
+        className="py-8 max-w-7xl mx-auto sm:px-6 lg:px-8 min-w-[200px]"
         onChange={onChangeValue}
       >
         {CONFIG.availableLangs.map((x) => createOption(x, t(`languages.${x}`)))}


### PR DESCRIPTION
## Summary
- 언어 선택 모달에 국기 이모지 추가 (🇺🇸🇬🇧 English, 🇰🇷 한국어, 🇯🇵 日本語, 🇪🇸 Español, 🇹🇿🇰🇪 Kiswahili, 🇨🇳 中文)
- 모바일에서 모달 타이틀과 닫기 버튼 겹침 수정 (BaseModal `pr-8`)
- 언어 전환 시 모달 크기 일관성 유지 (`min-w-[200px]`)

Closes #45

## Test plan
- [x] `npx tsc --noEmit` 통과
- [x] Playwright E2E 176개 테스트 전체 통과 (chromium, webkit, mobile-chrome, mobile-safari)
- [x] 모바일에서 타이틀-닫기 버튼 겹침 없음 확인
- [x] 언어 전환 시 모달 크기 일관 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)