### PR TITLE
feat: add modals to Create Puzzle page

### DIFF
--- a/e2e/modals.spec.ts
+++ b/e2e/modals.spec.ts
@@ -149,6 +149,52 @@ test.describe('Modals', () => {
     await screenshot(gamePage, '05-uppercase-removed-from-page')
   })
 
+  test('uppercase setting persists across page navigation', async ({ gamePage }) => {
+    // Daily: enable uppercase via settings (settings = 4th icon)
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(3).click()
+    await gamePage.locator('button[role="switch"]').click()
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
+    await expect(gamePage.locator('div.uppercase')).toBeVisible()
+    await screenshot(gamePage, '01-daily-uppercase-on')
+
+    // Daily → Practice
+    await gamePage.locator('a', { hasText: 'Practice' }).click()
+    await waitForGameReady(gamePage)
+    await expect(gamePage.locator('div.uppercase')).toBeVisible()
+    await screenshot(gamePage, '02-practice-uppercase-persisted')
+
+    // Practice → Daily
+    await gamePage.locator('a', { hasText: 'Daily' }).click()
+    await waitForGameReady(gamePage)
+    await expect(gamePage.locator('div.uppercase')).toBeVisible()
+    await screenshot(gamePage, '03-daily-uppercase-still-on')
+
+    // Daily → Create
+    await gamePage.locator('a', { hasText: 'Create' }).click()
+    await gamePage.locator('button', { hasText: 'Enter' }).waitFor({ state: 'visible' })
+    await expect(gamePage.locator('div.uppercase')).toBeVisible()
+    await screenshot(gamePage, '04-create-uppercase-persisted')
+
+    // Toggle off on Create page (settings = 3rd icon: translate, info, settings)
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
+    await gamePage.locator('button[role="switch"]').click()
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
+    await expect(gamePage.locator('div.uppercase')).not.toBeVisible()
+    await screenshot(gamePage, '05-create-uppercase-off')
+
+    // Create → Daily
+    await gamePage.locator('a', { hasText: 'Daily' }).click()
+    await waitForGameReady(gamePage)
+    await expect(gamePage.locator('div.uppercase')).not.toBeVisible()
+    await screenshot(gamePage, '06-daily-uppercase-off-persisted')
+
+    // Daily → Custom
+    await gamePage.goto(customPuzzlePath('crane', 'Alice'))
+    await waitForGameReady(gamePage)
+    await expect(gamePage.locator('div.uppercase')).not.toBeVisible()
+    await screenshot(gamePage, '07-custom-uppercase-off-persisted')
+  })
+
   test('donate modal opens and closes', async ({ gamePage }) => {
     // Click donate icon (CurrencyDollarIcon) — 5th icon
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(4).click()

--- a/src/components/pages/CreatePuzzlePage.tsx
+++ b/src/components/pages/CreatePuzzlePage.tsx
@@ -1,13 +1,21 @@
-import { useState, useRef, useCallback } from 'react'
+import { useState, useRef, useCallback, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { useTranslation } from 'react-i18next'
-import { InformationCircleIcon } from '@heroicons/react/outline'
+import {
+  InformationCircleIcon,
+  CogIcon,
+  CurrencyDollarIcon,
+  TranslateIcon,
+} from '@heroicons/react/outline'
 import classnames from 'classnames'
 import { isWordInWordList } from '../../lib/words'
 import { encodeCustomPuzzle } from '../../lib/customPuzzle'
-import { loadSettings } from '../../lib/localStorage'
+import { loadSettings, saveSettings } from '../../lib/localStorage'
 import { Keyboard } from '../keyboard/Keyboard'
 import { InfoModal } from '../modals/InfoModal'
+import { SettingsModal } from '../modals/SettingsModal'
+import { DonateModal } from '../modals/DonateModal'
+import { TranslateModal } from '../modals/TranslateModal'
 import { CONFIG } from '../../constants/config'
 
 const emptyLetters = () => Array.from({ length: CONFIG.wordLength }, () => '')
@@ -20,8 +28,15 @@ export const CreatePuzzlePage = () => {
   const [error, setError] = useState('')
   const [copied, setCopied] = useState(false)
   const [copiedUrl, setCopiedUrl] = useState('')
-  const [isUppercase] = useState(() => loadSettings().isUppercase)
+  const [isUppercase, setIsUppercase] = useState(() => loadSettings().isUppercase)
   const [isInfoModalOpen, setIsInfoModalOpen] = useState(false)
+  const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false)
+  const [isDonateModalOpen, setIsDonateModalOpen] = useState(false)
+  const [isI18nModalOpen, setIsI18nModalOpen] = useState(false)
+
+  useEffect(() => {
+    saveSettings({ isUppercase })
+  }, [isUppercase])
 
   const fallbackCopy = (text: string) => {
     const textarea = document.createElement('textarea')
@@ -136,16 +151,30 @@ export const CreatePuzzlePage = () => {
           <h1 className="text-xl font-bold">Wor&#x1F517;dle</h1>
           <p className="text-sm text-green-500">{t('createPuzzle')}</p>
         </div>
+        {CONFIG.availableLangs.length > 1 && (
+          <TranslateIcon
+            className="h-6 w-6 cursor-pointer"
+            onClick={() => setIsI18nModalOpen(true)}
+          />
+        )}
         <InformationCircleIcon
           className="h-6 w-6 cursor-pointer"
           onClick={() => setIsInfoModalOpen(true)}
+        />
+        <CogIcon
+          className="h-6 w-6 cursor-pointer"
+          onClick={() => setIsSettingsModalOpen(true)}
+        />
+        <CurrencyDollarIcon
+          className="h-6 w-6 cursor-pointer"
+          onClick={() => setIsDonateModalOpen(true)}
         />
       </div>
 
       <div className={isUppercase ? 'uppercase' : ''}>
         <div className="pb-6 min-h-[24rem]">
           <div className="w-80 mx-auto space-y-6">
-            <blockquote className="border-l-4 border-gray-300 pl-4 py-2 text-sm text-gray-500 italic whitespace-pre-line">
+            <blockquote className="border-l-4 border-gray-300 pl-4 py-2 text-sm text-gray-500 italic whitespace-pre-line normal-case">
               {t('createPuzzleDescription')}
             </blockquote>
 
@@ -190,6 +219,7 @@ export const CreatePuzzlePage = () => {
                     className={classnames(
                       'w-14 h-14 border-solid border-2 flex items-center justify-center mx-0.5 text-lg font-bold rounded text-center outline-none',
                       {
+                        'uppercase': isUppercase,
                         'bg-green-500 text-white border-green-500':
                           copied && letter,
                         'bg-white border-black': !copied && letter,
@@ -240,10 +270,24 @@ export const CreatePuzzlePage = () => {
         />
       </div>
 
+      <TranslateModal
+        isOpen={isI18nModalOpen}
+        handleClose={() => setIsI18nModalOpen(false)}
+      />
       <InfoModal
         isOpen={isInfoModalOpen}
         handleClose={() => setIsInfoModalOpen(false)}
         mode="create"
+      />
+      <SettingsModal
+        isOpen={isSettingsModalOpen}
+        handleClose={() => setIsSettingsModalOpen(false)}
+        isUppercase={isUppercase}
+        onToggleUppercase={() => setIsUppercase(!isUppercase)}
+      />
+      <DonateModal
+        isOpen={isDonateModalOpen}
+        handleClose={() => setIsDonateModalOpen(false)}
       />
 
       <div className="mx-auto mt-4 flex items-center justify-center gap-2">


### PR DESCRIPTION
## Summary
- Create 페이지 navbar에 Translate, Settings, Donate 모달 버튼 추가 (Statistics 제외)
- Settings 대문자 토글이 단어 셀에도 반영되도록 수정 (`<input>`에 직접 `uppercase` 클래스 적용)
- Create 페이지에서 변경한 설정이 localStorage에 저장되어 페이지 전환 시에도 유지

## Test plan
- [ ] `/#/create` 페이지에서 각 아이콘(Translate, Info, Settings, Donate) 클릭 시 모달 정상 동작 확인
- [ ] Settings 대문자 토글 시 단어 셀 및 키보드에 즉시 반영되는지 확인
- [ ] Daily → Practice → Create → Custom 간 페이지 전환 시 대문자 설정 유지 확인
- [ ] E2E 테스트 통과: `npx playwright test e2e/modals.spec.ts -g "uppercase setting persists"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)