### PR TITLE
feat: improve modal layout and fix e2e test

### DIFF
--- a/e2e/modals.spec.ts
+++ b/e2e/modals.spec.ts
@@ -83,8 +83,8 @@ test.describe('Modals', () => {
     await gamePage.goto('/#/create')
     await gamePage.locator('button', { hasText: 'Enter' }).waitFor({ state: 'visible' })
 
-    // Create page has info icon as first svg icon
-    await gamePage.locator('svg.h-6.w-6.cursor-pointer').first().click()
+    // Create page icons: translate(0), info(1), settings(2), donate(3)
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(1).click()
     await expect(gamePage.getByRole('heading', { name: 'Information' })).toBeVisible()
 
     // Tab 1: How to Create (default)

--- a/src/components/modals/BaseModal.tsx
+++ b/src/components/modals/BaseModal.tsx
@@ -19,7 +19,7 @@ export const BaseModal = ({ title, children, isOpen, handleClose }: Props) => {
         className="fixed z-10 inset-0 overflow-y-auto"
         onClose={handleClose}
       >
-        <div className="flex items-center justify-center min-h-screen py-10 px-4 text-center sm:block sm:p-0">
+        <div className="flex items-start justify-center min-h-screen pt-[20vh] px-4 text-center sm:block sm:p-0">
           <Transition.Child
             as={Fragment}
             enter="ease-out duration-300"
@@ -48,7 +48,7 @@ export const BaseModal = ({ title, children, isOpen, handleClose }: Props) => {
             leaveFrom="opacity-100 translate-y-0 sm:scale-100"
             leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
           >
-            <div className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle sm:max-w-sm sm:w-full sm:p-6">
+            <div className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle w-full sm:max-w-md sm:p-6">
               <div className="absolute right-4 top-4">
                 <XCircleIcon
                   className="h-6 w-6 cursor-pointer"


### PR DESCRIPTION
## Summary
- **모달 너비 확대**: `sm:max-w-sm` (384px) → `sm:max-w-md` (448px), 모바일에서 `w-full` 적용하여 Settings 토글 등이 찌그러지지 않도록 개선
- **모달 수직 위치 조정**: 화면 정중앙 → 상단 1/3 지점 (`pt-[20vh]`)으로 변경
- **e2e 테스트 수정**: Create 페이지 info 아이콘 인덱스 오류 수정 (`.first()` → `.nth(1)`)

## Test plan
- [x] `npx playwright test e2e/modals.spec.ts e2e/mobile-responsive.spec.ts` — 56 passed, 0 failed
- [ ] 로컬에서 Settings 모달 열어 uppercase 토글 레이아웃 확인
- [ ] 모바일 뷰포트에서 모달 너비/위치 확인
- [ ] 다른 모달(Info, Stats, Donate, Translate) 레이아웃 깨지지 않는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)