### PR TITLE
ci: remove e2e job from GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,36 +19,6 @@ jobs:
       - name: Build
         run: npm run build
 
-  e2e:
-    if: github.event_name == 'pull_request' && github.base_ref == 'main'
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - name: Install dependencies
-        run: npm install
-      - name: Install Playwright browsers
-        run: npx playwright install --with-deps chromium webkit
-      - name: Build
-        run: npm run build
-      - name: Start server
-        run: npx serve -s build -l 3000 &
-      - name: Wait for server
-        run: |
-          for i in $(seq 1 30); do
-            curl -s http://localhost:3000 > /dev/null && exit 0
-            sleep 1
-          done
-          echo "Server failed to start" && exit 1
-      - name: Run Playwright tests
-        run: npx playwright test
-      - name: Upload Playwright report
-        uses: actions/upload-artifact@v4
-        if: ${{ !cancelled() }}
-        with:
-          name: playwright-report
-          path: playwright-report/
-          retention-days: 30
-
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- GitHub Actions CI에서 e2e job 제거
- Playwright E2E가 CI 환경에서 안정적으로 동작하지 않아 일단 제거
- 로컬 E2E 테스트는 그대로 유지
- #66 에서 추적 중

🤖 Generated with [Claude Code](https://claude.com/claude-code)