### PR TITLE
fix: daily share 날짜 포맷을 ISO 8601 형식으로 변경

### DIFF
--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -33,7 +33,7 @@ export const shareStatus = (
   const dd = String(now.getUTCDate()).padStart(2, '0')
 
   const shareText =
-    `Wor\u{1F517}dle ${yyyy}/${mm}/${dd}` +
+    `Wor\u{1F517}dle ${yyyy}-${mm}-${dd}` +
     ' ' +
     `${lost ? 'X' : guesses.length}` +
     '/' +


### PR DESCRIPTION
## Summary
- Daily 공유 텍스트의 날짜 구분자를 슬래시(`/`)에서 대시(`-`)로 변경
- `Wor🔗dle 2026/03/06` → `Wor🔗dle 2026-03-06` (ISO 8601)

## Test plan
- [ ] Daily 모드에서 게임 완료 후 Share 버튼 클릭 → 클립보드 텍스트 날짜가 `YYYY-MM-DD` 형식인지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)