### PR TITLE
ci: restore Playwright E2E on GitHub Actions

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,6 +19,30 @@ jobs:
       - name: Build
         run: npm run build
 
+  e2e:
+    if: github.event_name == 'pull_request' && github.base_ref == 'main'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v5
+        with:
+          node-version: lts/*
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps
+      - name: Build
+        run: npm run build
+      - name: Run Playwright tests
+        run: npx playwright test
+      - uses: actions/upload-artifact@v4
+        if: ${{ !cancelled() }}
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 30
+
   deploy:
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
-  workers: process.env.CI ? 2 : undefined,
+  workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI ? 'github' : 'html',
   timeout: 30_000,
 
@@ -34,12 +34,12 @@ export default defineConfig({
     },
   ],
 
-  ...(!process.env.CI && {
-    webServer: {
-      command: 'npm run build && npx serve -s build -l 3000',
-      url: 'http://localhost:3000',
-      reuseExistingServer: true,
-      timeout: 120_000,
-    },
-  }),
+  webServer: {
+    command: process.env.CI
+      ? 'npx serve -s build -l 3000'
+      : 'npm run build && npx serve -s build -l 3000',
+    url: 'http://localhost:3000',
+    reuseExistingServer: true,
+    timeout: 120_000,
+  },
 })


### PR DESCRIPTION
Related to #66
## Summary
- GitHub Actions CI에 Playwright E2E 테스트 job 복원 (main 대상 PR에서만 실행)
- `actions/runner-images#11347` (apt-get hang) 해결 확인 → 공식 권장 방식 (`npx playwright install --with-deps`) 사용
- CI workers를 1로 변경 (Playwright 공식 권장: 안정성/재현성 우선)
- webServer 설정을 CI에서도 활성화 (CI에서는 serve-only, 로컬에서는 build+serve)

## Changes
| 파일 | 변경 |
|------|------|
| `playwright.config.ts` | workers 2→1 (CI), webServer CI 분기 |
| `.github/workflows/publish.yml` | e2e job 추가 |

## Test plan
- [x] 로컬 E2E 전체 실행: 202 passed / 4 failed (기존 uppercase toggle 이슈) / 18 skipped
- [ ] `release/v1.3.0` → `main` PR에서 e2e job 트리거 확인
- [ ] CI에서 Playwright 브라우저 설치 및 테스트 통과 확인

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)