### PR TITLE
fix: 공유 URL 해시 제거 통일

### DIFF
--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -20,7 +20,9 @@ export const shareCustomStatus = (
     (excludeUrl
       ? ''
       : '\n\n' +
-        window.location.href.replace(`${window.location.protocol}//`, ''))
+        window.location.href
+          .replace(`${window.location.protocol}//`, '')
+          .replace(/#.*$/, ''))
 
   navigator.clipboard.writeText(shareText)
 }
@@ -47,7 +49,9 @@ export const shareStatus = (
     (excludeUrl
       ? ''
       : '\n\n' +
-        window.location.href.replace(`${window.location.protocol}//`, ''))
+        window.location.href
+          .replace(`${window.location.protocol}//`, '')
+          .replace(/#.*$/, ''))
 
   navigator.clipboard.writeText(shareText)
 }


### PR DESCRIPTION
## Summary
- Daily/Custom 공유 시 URL에 포함되던 `/#/`를 제거하여 Calendar 공유와 동일하게 통일
- 기능적으로 해시 유무와 무관하게 동작하지만, 공유 텍스트의 표기 일관성을 위한 수정

## Test plan
- [x] Daily 모드에서 공유 → URL에 `/#/` 없이 출력되는지 확인
- [x] Custom 모드에서 공유 → URL에 `/#/custom/...` 없이 출력되는지 확인
- [x] Calendar 공유 → 기존과 동일하게 동작하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)