### PR TITLE
fix: Custom 공유 URL 해시 제거 롤백

### DIFF
--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -20,9 +20,7 @@ export const shareCustomStatus = (
     (excludeUrl
       ? ''
       : '\n\n' +
-        window.location.href
-          .replace(`${window.location.protocol}//`, '')
-          .replace(/#.*$/, ''))
+        window.location.href.replace(`${window.location.protocol}//`, ''))
 
   navigator.clipboard.writeText(shareText)
 }


### PR DESCRIPTION
## Summary
- #75 스쿼시 머지 시 Custom 공유 URL 롤백 커밋이 누락됨
- Custom 모드는 `/#/custom/:code` 경로가 URL에 포함되어야 다른 사람이 같은 퍼즐을 플레이할 수 있으므로 해시 제거를 적용하면 안 됨
- `shareCustomStatus`에서 `.replace(/#.*$/, '')` 제거

## Test plan
- [ ] Custom 모드에서 공유 → URL에 `/#/custom/:code`가 포함되는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)