### PR TITLE
ci: Playwright dot reporter 추가

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: process.env.CI ? 'github' : 'html',
+  reporter: process.env.CI ? [['github'], ['dot']] : 'html',
   timeout: 30_000,
 
   use: {


### PR DESCRIPTION
## Summary
- CI에서 Playwright `github` reporter만 사용하면 성공한 테스트는 로그에 아무것도 출력되지 않아 진행 상황 파악이 불가능
- `[['github'], ['dot']]` 복수 reporter로 변경하여 테스트마다 `·`(pass) `F`(fail) 표시

## Test plan
- [ ] CI 로그에서 Playwright 테스트 진행 시 dot 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)