### PR TITLE
ci: Playwright CI reporter를 list로 변경

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -6,7 +6,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 0,
   workers: process.env.CI ? 1 : undefined,
-  reporter: process.env.CI ? [['github'], ['dot']] : 'html',
+  reporter: process.env.CI ? [['github'], ['list']] : 'html',
   timeout: 30_000,
 
   use: {


### PR DESCRIPTION
## Summary
- `dot` reporter는 newline 없이 문자를 출력하여 GitHub Actions에서 줄 단위 버퍼링에 걸려 실시간 표시 불가
- `list` reporter는 테스트당 한 줄씩 출력하므로 CI 로그에서 즉시 확인 가능
- `[['github'], ['dot']]` → `[['github'], ['list']]`로 변경

## Test plan
- [ ] CI 로그에서 테스트 실행 시 한 줄씩 실시간 출력 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)