### PR TITLE
docs: PR 생성 가이드라인 및 /pr 스킬 추가

### DIFF
--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: bump-version
 description: 프로젝트 내 모든 버전 정보를 일괄 업데이트합니다.
-allowed-tools: Read, Edit, Bash(npm version *)
 argument-hint: <version> (e.g. 1.1.0)
 ---
 

--- a/.claude/skills/cleanup/SKILL.md
+++ b/.claude/skills/cleanup/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: cleanup
 description: feature 브랜치 머지 후 로컬 정리 (release 전환, pull, 브랜치 삭제, prune)
-allowed-tools: Bash(git *)
 ---
 
 # Post-Merge Cleanup

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,0 +1,80 @@
+---
+name: pr
+description: 현재 브랜치의 PR을 생성합니다 (label, assignee, milestone, development 자동 설정).
+allowed-tools: Bash(git *), Bash(gh *), Read, Grep
+---
+
+# PR 생성
+
+현재 브랜치 유형에 따라 적절한 PR을 생성합니다.
+
+- `feature/*` 브랜치 → `release/*` 브랜치로 PR
+- `release/*` 브랜치 → `main`으로 PR
+
+## 절차
+
+1. **브랜치 유형 판별**
+   - 현재 브랜치가 `feature/*`이면 → feature PR 흐름
+   - 현재 브랜치가 `release/*`이면 → release PR 흐름
+   - 둘 다 아니면 중단하고 사용자에게 안내
+
+2. **사전 확인**
+   - `git log`로 base 브랜치 대비 커밋 목록 확인.
+   - `git diff <base>...HEAD`로 변경 내용 파악.
+
+3. **PR 메타데이터 결정**
+
+   ### Feature PR (feature → release)
+
+   - **base**: 대상 release 브랜치 (브랜치 히스토리에서 추론, 불확실하면 사용자에게 질문)
+   - **title**: 변경 내용 요약 (70자 이내). conventional commit 접두사 사용 (feat:, fix:, docs:, style:, refactor:, test:, ci:, chore:).
+   - **label**: 변경 내용에 맞는 라벨 선택 (복수 가능):
+     - `✨ enhancement` — 새 기능
+     - `🐛 bug` — 버그 수정
+     - `📝 documentation` — 문서
+     - `🎨 UI/UX` — 디자인/UI 개선
+     - `💰 donation` — 후원 관련
+     - `🧑‍💻 devops` — 개발 환경/CI/테스트
+     - `💥 breaking change` — 호환성 깨지는 변경
+     - `browser: chrome`, `browser: safari`, `platform: PC`, `platform: mobile` — 해당 시
+   - **milestone**: base release 브랜치의 버전 (예: release/v1.4.0 → `v1.4.0`). milestone이 없으면 `gh api`로 먼저 생성.
+   - **assignee**: `Ootzk`
+   - **body**: 관련 이슈가 있으면 `Closes #이슈번호` 포함. Summary + Test plan 형식.
+
+   ### Release PR (release → main)
+
+   - **base**: `main`
+   - **title**: 반드시 `Release v{version}` 형식 (예: `Release v1.4.0`). 브랜치명에서 버전 추출.
+   - **label**: `🔖 versioning` (필수). 추가 라벨은 내용에 따라.
+   - **milestone**: 해당 release 버전.
+   - **assignee**: `Ootzk`
+   - **body**: 이 body가 GitHub Release 본문으로 자동 사용됨. 아래 내용을 포함:
+     - `Closes #이슈번호` — 이 release에서 해결된 **모든** 이슈를 나열 (Development sidebar 자동 연결 + 자동 close)
+     - release에 포함된 주요 변경 사항 요약 (머지된 PR 목록 기반)
+
+4. **원격 push 및 PR 생성**
+   - 원격에 push되지 않았으면 `git push -u origin <branch>`.
+   - PR 생성:
+     ```
+     gh pr create \
+       --repo Ootzk/Wor-chain-dle \
+       --base <base-branch> \
+       --title "<title>" \
+       --label "<label1>" --label "<label2>" \
+       --assignee Ootzk \
+       --milestone "<version>" \
+       --body "$(cat <<'EOF'
+     Closes #이슈번호 (있는 경우)
+
+     ## Summary
+     - ...
+
+     ## Test plan (feature PR만)
+     - ...
+
+     🤖 Generated with [Claude Code](https://claude.com/claude-code)
+     EOF
+     )"
+     ```
+
+5. **결과 출력**: PR URL을 사용자에게 보여줌.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -1,7 +1,6 @@
 ---
 name: pr
 description: 현재 브랜치의 PR을 생성합니다 (label, assignee, milestone, development 자동 설정).
-allowed-tools: Bash(git *), Bash(gh *), Read, Grep
 ---
 
 # PR 생성
@@ -14,9 +13,9 @@ allowed-tools: Bash(git *), Bash(gh *), Read, Grep
 ## 절차
 
 1. **브랜치 유형 판별**
-   - 현재 브랜치가 `feature/*`이면 → feature PR 흐름
    - 현재 브랜치가 `release/*`이면 → release PR 흐름
-   - 둘 다 아니면 중단하고 사용자에게 안내
+   - 현재 브랜치가 `main`이면 → 중단하고 사용자에게 안내
+   - 그 외 모든 브랜치 → feature PR 흐름
 
 2. **사전 확인**
    - `git log`로 base 브랜치 대비 커밋 목록 확인.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,6 +95,30 @@ docker run -d -p 3000:3000 wor-chain-dle
 - **PR 머지는 항상 개발자가 직접 수행.** Claude는 PR 생성까지만.
 - **PR 생성 시 반드시 `--repo Ootzk/Wor-chain-dle`을 명시한다.** 이 프로젝트는 fork 기반이므로, `--repo` 없이 `gh pr create`를 실행하면 upstream(원본 저장소)으로 PR이 올라갈 수 있다.
 
+### PR 생성 시 필수 설정
+
+PR을 만들 때 아래 항목을 반드시 설정한다:
+
+- **Label**: 내용에 맞는 라벨을 `--label`로 지정. 복수 가능. 사용 가능한 라벨:
+  - `✨ enhancement` — 새 기능
+  - `🐛 bug` — 버그 수정
+  - `📝 documentation` — 문서
+  - `🎨 UI/UX` — 디자인/UI 개선
+  - `💰 donation` — 후원 관련
+  - `🔖 versioning` — release → main PR 전용
+  - `🧑‍💻 devops` — 개발 환경/CI/테스트
+  - `💥 breaking change` — 호환성 깨지는 변경
+  - `browser: chrome`, `browser: safari` — 브라우저 한정
+  - `platform: PC`, `platform: mobile` — 플랫폼 한정
+- **Assignee**: `--assignee Ootzk`
+- **Milestone**: 머지 대상 release 버전을 `--milestone`으로 지정 (예: `v1.4.0`). milestone이 아직 없으면 먼저 생성.
+
+### PR-Issue 연결 (Development sidebar)
+
+- **feature PR → release 브랜치**: body에 `Closes #이슈번호`를 작성하되, 타겟이 main이 아니므로 Development sidebar 자동 연결은 안 됨. 참조 용도.
+- **release PR → main**: body에 `Closes #이슈번호`를 나열하면 Development sidebar 자동 연결 + 이슈 자동 close. 해당 release에서 해결된 모든 이슈를 포함할 것.
+- GitHub API 한계로 feature PR의 Development sidebar 연결은 수동으로만 가능.
+
 ## Version Management
 
 코드 내 버전 정보가 있는 곳:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -91,7 +91,7 @@ docker run -d -p 3000:3000 wor-chain-dle
 
 - `main`: 항상 배포 가능한 상태. 머지될 때마다 버전 태그 등록.
 - `release/{version}`: 다음 버전 개발 브랜치. main에서 생성. 해당 버전이 어느 정도 완성되면 main으로 PR을 보내서 머지. **PR 제목은 반드시 `Release v{version}` 형식** (예: `Release v1.2.0`). 이 PR의 body가 GitHub Release 본문으로 자동 사용됨.
-- `feature/{contents}`: 기능별 브랜치. release 브랜치에서 생성. 작업 완료 후 release 브랜치로 PR을 만들어서 머지.
+- 기능별 브랜치: release 브랜치에서 생성. 작업 완료 후 release 브랜치로 PR을 만들어서 머지. 이름은 자유 (예: `feature/calendar`, `improve-e2e`, `fix-share-bug` 등). `main`과 `release/*`가 아닌 브랜치는 모두 기능 브랜치로 간주.
 - **PR 머지는 항상 개발자가 직접 수행.** Claude는 PR 생성까지만.
 - **PR 생성 시 반드시 `--repo Ootzk/Wor-chain-dle`을 명시한다.** 이 프로젝트는 fork 기반이므로, `--repo` 없이 `gh pr create`를 실행하면 upstream(원본 저장소)으로 PR이 올라갈 수 있다.
 


### PR DESCRIPTION
## Summary
- CLAUDE.md에 PR 생성 시 필수 설정 가이드라인 추가 (label, assignee, milestone, development 연결)
- `/pr` 스킬 신규 생성 (feature→release, release→main PR 자동 생성)
- 브랜치 네이밍 자유화 (main, release/* 외 모든 브랜치를 기능 브랜치로 간주)
- 기존 스킬에서 미지원 속성 `allowed-tools` 제거

## Test plan
- [x] `/pr` 스킬로 현재 PR 생성 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)