### PR TITLE
feat: 단어 갱신 타이밍을 UTC에서 디바이스 로컬 타임존 자정으로 변경

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,6 +9,7 @@ Based on [AnyLanguage-Word-Guessing-Game](https://github.com/roedoejet/AnyLangua
 - React 17 + TypeScript + Tailwind CSS 3
 - Create React App (react-scripts 5)
 - React Router v5 (HashRouter)
+- Temporal API (`temporal-polyfill`) — DST-safe 날짜 계산, Date 완전 대체
 - i18next (en, ko, ja, es, sw, zh — 번역 리소스 JS 번들 인라인)
 - Playwright (E2E 테스트 — Chromium, WebKit, iPhone 13, Pixel 5)
 - GoatCounter 애널리틱스 (쿠키 없음, 경량)
@@ -28,7 +29,7 @@ src/
     wordlist.ts                  ← 정답 단어 목록 (2,315개, 고정 시드 셔플)
     validGuesses.ts              ← 유효 추측 단어 목록 (10,656개, 정답과 중복 없음)
   lib/
-    words.ts                     ← 오늘의 단어 선택 (UTC 기반), 단어 검증
+    words.ts                     ← 오늘의 단어 선택 (로컬 타임존 기반, Temporal API), 단어 검증
     statuses.ts                  ← 글자 상태 판정 (correct/present/absent)
     chain.ts                     ← 체인 규칙 유틸 (체인 인덱스, dead end 판정)
     share.ts                     ← 공유 텍스트 생성 (이모지 그리드 + box-drawing 체인 경로 + 달력 월별 공유)
@@ -133,7 +134,7 @@ PR을 만들 때 아래 항목을 반드시 설정한다:
 
 | 항목 | Daily | Practice | Custom |
 | ------ | ------- | ---------- | -------- |
-| 정답 출처 | WORDS (매일 UTC 리셋) | WORDS (랜덤) | 출제자 지정 (WORDS + VALIDGUESSES) |
+| 정답 출처 | WORDS (매일 로컬 자정 리셋) | WORDS (랜덤) | 출제자 지정 (WORDS + VALIDGUESSES) |
 | 통계 저장 | `gameStats` | X | `customGameStats` |
 | 날짜별 기록 | `dailyHistory` | X | X |
 | 게임 상태 저장 | O | X | X |
@@ -145,18 +146,18 @@ PR을 만들 때 아래 항목을 반드시 설정한다:
 - **출제 페이지**: `/#/create` — Keyboard 컴포넌트 재사용, 셀은 readOnly (모바일 가상 키보드 억제)
 - **출제자 이름**: 최대 10자 제한 (오버레이 깨짐 방지)
 
-## UTC 기준 시간
+## 로컬 타임존 기반 시간
 
-게임 전체가 UTC 기준으로 동작한다. 로컬 타임을 사용하면 안 됨.
+게임 전체가 디바이스 로컬 타임존 기준으로 동작한다. `Date` 객체 대신 `Temporal` API (`temporal-polyfill`)를 사용.
 
-- **단어 선택**: `solutionIndex`가 `CONFIG.startDate` epoch부터 UTC 자정 기준으로 계산
-- **Daily subtitle**: `App.tsx`에서 `getUTCFullYear/Month/Date`로 표시 (로컬 `toLocaleDateString` 사용 금지)
-- **document.title**: 동일하게 UTC 기반
-- **달력 today 판정**: `Calendar.tsx`에서 `getUTCDate()`로 오늘 날짜 결정
-- **dailyHistory 인덱스**: UTC 기반 `dateToSolutionIndex`로 저장/조회
-- **공유 텍스트**: `share.ts`에서 `getUTCFullYear/Month/Date`로 날짜 생성
+- **단어 선택**: `Temporal.Now.plainDateISO()`로 오늘 날짜 취득, `today.since(epoch).days`로 solutionIndex 계산 (DST 무관)
+- **Daily subtitle / document.title**: `dateToKey(Temporal.Now.plainDateISO())`로 표시
+- **달력 today 판정**: `Temporal.PlainDate.compare()`로 오늘/미래/과거 결정
+- **dailyHistory 키**: `"yyyy-mm-dd"` 날짜 문자열 (구버전 정수 key는 앱 로드 시 자동 마이그레이션)
+- **공유 텍스트**: `Temporal.Now.plainDateISO().toString()`으로 날짜 생성
+- **카운트다운 타이머**: `Temporal.ZonedDateTime.epochMilliseconds`로 다음 날 로컬 자정 밀리초 계산
 
-로컬 타임을 쓰면 subtitle과 달력 today가 불일치하고, dailyHistory 인덱스와 달력 셀 매핑이 어긋남.
+`Date` 객체는 앱 런타임에서 사용하지 않는다. 마이그레이션 로직에서도 `Temporal.PlainDate`만 사용.
 
 ## Routing
 
@@ -164,7 +165,7 @@ HashRouter 기반 라우팅 (`src/index.tsx`):
 
 | 경로 | 컴포넌트 | 모드 | 설명 |
 | --- | --- | --- | --- |
-| `/#/` | DailyPage | daily | UTC 기반 매일 고정 정답 |
+| `/#/` | DailyPage | daily | 로컬 자정 기반 매일 고정 정답 |
 | `/#/practice` | PracticePage | practice | 랜덤 단어 (매 접속마다 새로 생성) |
 | `/#/create` | CreatePuzzlePage | — | 커스텀 퍼즐 출제 페이지 |
 | `/#/custom/:code` | CustomPage | custom | Base64 디코딩 후 단어 검증, 실패 시 `/`로 리다이렉트 |
@@ -217,8 +218,9 @@ Daily 모드 게임 완료 시 `dailyHistory` (localStorage)에 날짜별 결과
 **데이터 구조** (`src/lib/dailyHistory.ts`):
 
 - `DayResult = { guessCount: number, won: boolean }` — 각 날짜의 게임 결과
-- `DailyHistory = Record<number, DayResult>` — key는 solutionIndex (CONFIG.startDate epoch 기준 일수)
-- localStorage 키: `dailyHistory` (결과), `dailyHistoryStartIndex` (달력 추적 시작 인덱스)
+- `DailyHistory = Record<string, DayResult>` — key는 `"yyyy-mm-dd"` ISO 날짜 문자열
+- localStorage 키: `dailyHistory` (결과), `dailyHistoryStartDate` (달력 추적 시작 날짜, `"yyyy-mm-dd"`)
+- 마이그레이션: 구버전 정수 key → 날짜 key 자동 변환 (`migrateDailyHistory()`, 앱 로드 시 1회)
 
 **달력 UI** (`src/components/calendar/`):
 

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -1,30 +1,28 @@
 import { test, expect, waitForGameReady, screenshot } from './fixtures/game.fixture'
 import { Page } from '@playwright/test'
 
-// Mirrors CONFIG.startDate and dailyHistory.ts index calculation
-const START_MS = Date.UTC(2026, 1, 16) // Feb 16, 2026
-const DAY_MS = 86400000
-const toIndex = (y: number, m: number, d: number) =>
-  Math.floor((Date.UTC(y, m, d) - START_MS) / DAY_MS)
+/** Format a date key as "yyyy-mm-dd" */
+const toDateKey = (y: number, m: number, d: number) =>
+  `${y}-${String(m + 1).padStart(2, '0')}-${String(d).padStart(2, '0')}`
 
 /** Inject fake dailyHistory into localStorage and reload */
 async function injectHistory(
   page: Page,
   entries: { y: number; m: number; d: number; guessCount: number; won: boolean }[]
 ) {
-  const history: Record<number, { guessCount: number; won: boolean }> = {}
-  let minIndex = Infinity
+  const history: Record<string, { guessCount: number; won: boolean }> = {}
+  let minKey = ''
   for (const e of entries) {
-    const idx = toIndex(e.y, e.m, e.d)
-    history[idx] = { guessCount: e.guessCount, won: e.won }
-    if (idx < minIndex) minIndex = idx
+    const key = toDateKey(e.y, e.m, e.d)
+    history[key] = { guessCount: e.guessCount, won: e.won }
+    if (!minKey || key < minKey) minKey = key
   }
   await page.evaluate(
-    ({ h, si }) => {
+    ({ h, sd }) => {
       localStorage.setItem('dailyHistory', JSON.stringify(h))
-      localStorage.setItem('dailyHistoryStartIndex', si.toString())
+      localStorage.setItem('dailyHistoryStartDate', sd)
     },
-    { h: history, si: minIndex }
+    { h: history, sd: minKey }
   )
   await page.reload()
   await waitForGameReady(page)
@@ -45,10 +43,10 @@ test.describe('Calendar', () => {
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(CALENDAR_ICON).click()
     await expect(gamePage.getByRole('heading', { name: 'Calendar' })).toBeVisible()
 
-    // Current month label (e.g. "March 2026")
+    // Current month label (e.g. "March 2026") — uses local time
     const now = new Date()
-    const monthLabel = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
-      .toLocaleDateString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' })
+    const monthLabel = new Date(now.getFullYear(), now.getMonth(), 1)
+      .toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
     await expect(gamePage.locator(`text=${monthLabel}`)).toBeVisible()
 
     // Weekday header — Sunday start by default
@@ -72,8 +70,8 @@ test.describe('Calendar', () => {
 
   test('displays win and loss indicators', async ({ gamePage }) => {
     const now = new Date()
-    const y = now.getUTCFullYear()
-    const m = now.getUTCMonth()
+    const y = now.getFullYear()
+    const m = now.getMonth()
 
     await injectHistory(gamePage, [
       { y, m, d: 1, guessCount: 3, won: true },
@@ -99,8 +97,8 @@ test.describe('Calendar', () => {
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(CALENDAR_ICON).click()
 
     const now = new Date()
-    const currentLabel = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), 1))
-      .toLocaleDateString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' })
+    const currentLabel = new Date(now.getFullYear(), now.getMonth(), 1)
+      .toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
     await expect(gamePage.locator(`text=${currentLabel}`)).toBeVisible()
 
     // Today button disabled on current month
@@ -154,7 +152,7 @@ test.describe('Calendar', () => {
     // Inject data and reopen
     const now = new Date()
     await injectHistory(gamePage, [
-      { y: now.getUTCFullYear(), m: now.getUTCMonth(), d: 1, guessCount: 4, won: true },
+      { y: now.getFullYear(), m: now.getMonth(), d: 1, guessCount: 4, won: true },
     ])
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(CALENDAR_ICON).click()
 

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -1,3 +1,4 @@
+import { Temporal } from 'temporal-polyfill'
 import { test, expect, waitForGameReady, screenshot } from './fixtures/game.fixture'
 import { Page } from '@playwright/test'
 
@@ -44,9 +45,9 @@ test.describe('Calendar', () => {
     await expect(gamePage.getByRole('heading', { name: 'Calendar' })).toBeVisible()
 
     // Current month label (e.g. "March 2026") — uses local time
-    const now = new Date()
-    const monthLabel = new Date(now.getFullYear(), now.getMonth(), 1)
-      .toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+    const today = Temporal.Now.plainDateISO()
+    const firstOfMonth = today.with({ day: 1 })
+    const monthLabel = firstOfMonth.toLocaleString('en-US', { month: 'long', year: 'numeric' })
     await expect(gamePage.locator(`text=${monthLabel}`)).toBeVisible()
 
     // Weekday header — Sunday start by default
@@ -69,9 +70,9 @@ test.describe('Calendar', () => {
   })
 
   test('displays win and loss indicators', async ({ gamePage }) => {
-    const now = new Date()
-    const y = now.getFullYear()
-    const m = now.getMonth()
+    const today = Temporal.Now.plainDateISO()
+    const y = today.year
+    const m = today.month - 1 // 0-indexed for toDateKey
 
     await injectHistory(gamePage, [
       { y, m, d: 1, guessCount: 3, won: true },
@@ -96,9 +97,9 @@ test.describe('Calendar', () => {
   test('month navigation', async ({ gamePage }) => {
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(CALENDAR_ICON).click()
 
-    const now = new Date()
-    const currentLabel = new Date(now.getFullYear(), now.getMonth(), 1)
-      .toLocaleDateString('en-US', { month: 'long', year: 'numeric' })
+    const today = Temporal.Now.plainDateISO()
+    const firstOfMonth = today.with({ day: 1 })
+    const currentLabel = firstOfMonth.toLocaleString('en-US', { month: 'long', year: 'numeric' })
     await expect(gamePage.locator(`text=${currentLabel}`)).toBeVisible()
 
     // Today button disabled on current month
@@ -150,9 +151,9 @@ test.describe('Calendar', () => {
     await gamePage.keyboard.press('Escape')
 
     // Inject data and reopen
-    const now = new Date()
+    const today = Temporal.Now.plainDateISO()
     await injectHistory(gamePage, [
-      { y: now.getFullYear(), m: now.getMonth(), d: 1, guessCount: 4, won: true },
+      { y: today.year, m: today.month - 1, d: 1, guessCount: 4, won: true },
     ])
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(CALENDAR_ICON).click()
 

--- a/e2e/local-timezone.spec.ts
+++ b/e2e/local-timezone.spec.ts
@@ -1,0 +1,245 @@
+import { test as base, expect, Page } from '@playwright/test'
+import { PATCH_NOTES_VERSION } from '../src/constants/config'
+import { waitForGameReady, screenshot } from './fixtures/game.fixture'
+
+/**
+ * Tests for local timezone word reset and dailyHistory migration.
+ *
+ * Uses Playwright clock.setFixedTime() + timezoneId to control
+ * the browser's time and timezone independently.
+ */
+
+// Bare test without gamePage fixture — we need custom browser contexts
+const test = base
+
+const CALENDAR_ICON = 3
+
+/** Common initScript to suppress patch notes and set English */
+function addGameInitScript(page: Page) {
+  return page.addInitScript((version) => {
+    localStorage.setItem('seenPatchNotesVersion', version)
+    localStorage.setItem('i18nextLng', 'en')
+    window.addEventListener('keydown', (e) => {
+      if (
+        e.code === 'Backspace' &&
+        !['INPUT', 'TEXTAREA'].includes(
+          (document.activeElement?.tagName ?? '')
+        )
+      ) {
+        e.preventDefault()
+      }
+    })
+  }, PATCH_NOTES_VERSION)
+}
+
+test.describe('Local Timezone', () => {
+  test('subtitle shows local date matching browser timezone', async ({ browser }) => {
+    // UTC 2026-03-15T22:00:00Z
+    // Tokyo (UTC+9): 2026-03-16 07:00 → subtitle should show 2026-03-16
+    // New York (UTC-4 EDT): 2026-03-15 18:00 → subtitle should show 2026-03-15
+
+    const tokyoCtx = await browser.newContext({ timezoneId: 'Asia/Tokyo' })
+    const tokyoPage = await tokyoCtx.newPage()
+    await addGameInitScript(tokyoPage)
+    await tokyoPage.clock.setFixedTime(new Date('2026-03-15T22:00:00Z'))
+    await tokyoPage.goto('/')
+    await waitForGameReady(tokyoPage)
+
+    const tokyoSubtitle = tokyoPage.locator('p.text-sm.text-gray-500')
+    await expect(tokyoSubtitle).toContainText('2026-03-16')
+    await screenshot(tokyoPage, '01-tokyo-subtitle')
+    await tokyoCtx.close()
+
+    const nyCtx = await browser.newContext({ timezoneId: 'America/New_York' })
+    const nyPage = await nyCtx.newPage()
+    await addGameInitScript(nyPage)
+    await nyPage.clock.setFixedTime(new Date('2026-03-15T22:00:00Z'))
+    await nyPage.goto('/')
+    await waitForGameReady(nyPage)
+
+    const nySubtitle = nyPage.locator('p.text-sm.text-gray-500')
+    await expect(nySubtitle).toContainText('2026-03-15')
+    await screenshot(nyPage, '02-newyork-subtitle')
+    await nyCtx.close()
+  })
+
+  test('same local date in different timezones shows same word', async ({ browser }) => {
+    // Both timezones see "2026-06-01" as local date, but at different UTC instants
+    // Tokyo: 2026-06-01 12:00 JST = 2026-06-01T03:00:00Z
+    // New York: 2026-06-01 12:00 EDT = 2026-06-01T16:00:00Z
+
+    const tokyoCtx = await browser.newContext({ timezoneId: 'Asia/Tokyo' })
+    const tokyoPage = await tokyoCtx.newPage()
+    await addGameInitScript(tokyoPage)
+    await tokyoPage.clock.setFixedTime(new Date('2026-06-01T03:00:00Z'))
+    await tokyoPage.goto('/')
+    await waitForGameReady(tokyoPage)
+    const tokyoTitle = await tokyoPage.title()
+    await tokyoCtx.close()
+
+    const nyCtx = await browser.newContext({ timezoneId: 'America/New_York' })
+    const nyPage = await nyCtx.newPage()
+    await addGameInitScript(nyPage)
+    await nyPage.clock.setFixedTime(new Date('2026-06-01T16:00:00Z'))
+    await nyPage.goto('/')
+    await waitForGameReady(nyPage)
+    const nyTitle = await nyPage.title()
+    await nyCtx.close()
+
+    // Both should contain 2026-06-01 and have the same title (= same word)
+    expect(tokyoTitle).toContain('2026-06-01')
+    expect(nyTitle).toContain('2026-06-01')
+    expect(tokyoTitle).toBe(nyTitle)
+  })
+
+  test('different local dates show different words', async ({ browser }) => {
+    // Same UTC instant, but different local dates due to timezone
+    // UTC 2026-04-10T23:00:00Z
+    // Tokyo (UTC+9): 2026-04-11 08:00
+    // Los Angeles (UTC-7 PDT): 2026-04-10 16:00
+
+    const tokyoCtx = await browser.newContext({ timezoneId: 'Asia/Tokyo' })
+    const tokyoPage = await tokyoCtx.newPage()
+    await addGameInitScript(tokyoPage)
+    await tokyoPage.clock.setFixedTime(new Date('2026-04-10T23:00:00Z'))
+    await tokyoPage.goto('/')
+    await waitForGameReady(tokyoPage)
+    const tokyoTitle = await tokyoPage.title()
+    await tokyoCtx.close()
+
+    const laCtx = await browser.newContext({ timezoneId: 'America/Los_Angeles' })
+    const laPage = await laCtx.newPage()
+    await addGameInitScript(laPage)
+    await laPage.clock.setFixedTime(new Date('2026-04-10T23:00:00Z'))
+    await laPage.goto('/')
+    await waitForGameReady(laPage)
+    const laTitle = await laPage.title()
+    await laCtx.close()
+
+    // Tokyo sees April 11, LA sees April 10 — different words
+    expect(tokyoTitle).toContain('2026-04-11')
+    expect(laTitle).toContain('2026-04-10')
+    expect(tokyoTitle).not.toBe(laTitle)
+  })
+})
+
+test.describe('Daily History Migration', () => {
+  test('legacy integer-key dailyHistory is migrated to date-key format', async ({ browser }) => {
+    const ctx = await browser.newContext({ timezoneId: 'Asia/Tokyo' })
+    const page = await ctx.newPage()
+    await addGameInitScript(page)
+
+    // Inject legacy format: integer solutionIndex keys
+    // epoch = 2026-02-16, so index 0 = 2026-02-16, index 1 = 2026-02-17, etc.
+    // We set clock to March so these dates are in the past
+    await page.addInitScript(() => {
+      const legacyHistory: Record<number, { guessCount: number; won: boolean }> = {
+        0: { guessCount: 3, won: true },   // 2026-02-16
+        1: { guessCount: 5, won: true },   // 2026-02-17
+        2: { guessCount: 6, won: false },  // 2026-02-18
+      }
+      localStorage.setItem('dailyHistory', JSON.stringify(legacyHistory))
+      localStorage.setItem('dailyHistoryStartIndex', '0')
+    })
+
+    await page.clock.setFixedTime(new Date('2026-03-10T06:00:00Z'))
+    await page.goto('/')
+    await waitForGameReady(page)
+
+    // Check that migration happened: keys should now be date strings
+    const migrated = await page.evaluate(() => {
+      const raw = localStorage.getItem('dailyHistory')
+      return raw ? JSON.parse(raw) : null
+    })
+
+    expect(migrated).not.toBeNull()
+    expect(migrated['2026-02-16']).toEqual({ guessCount: 3, won: true })
+    expect(migrated['2026-02-17']).toEqual({ guessCount: 5, won: true })
+    expect(migrated['2026-02-18']).toEqual({ guessCount: 6, won: false })
+
+    // Integer keys should be gone
+    expect(migrated['0']).toBeUndefined()
+    expect(migrated['1']).toBeUndefined()
+    expect(migrated['2']).toBeUndefined()
+
+    // dailyHistoryStartIndex → dailyHistoryStartDate
+    const startDate = await page.evaluate(() =>
+      localStorage.getItem('dailyHistoryStartDate')
+    )
+    expect(startDate).toBe('2026-02-16')
+
+    const legacyStartIndex = await page.evaluate(() =>
+      localStorage.getItem('dailyHistoryStartIndex')
+    )
+    expect(legacyStartIndex).toBeNull()
+
+    await ctx.close()
+  })
+
+  test('migrated data displays correctly in calendar', async ({ browser }) => {
+    const ctx = await browser.newContext({ timezoneId: 'Asia/Tokyo' })
+    const page = await ctx.newPage()
+    await addGameInitScript(page)
+
+    // Inject legacy data for March 2026
+    // epoch = 2026-02-16, index 13 = 2026-03-01, index 14 = 2026-03-02, index 15 = 2026-03-03
+    await page.addInitScript(() => {
+      const legacyHistory: Record<number, { guessCount: number; won: boolean }> = {
+        13: { guessCount: 2, won: true },  // 2026-03-01
+        14: { guessCount: 4, won: true },  // 2026-03-02
+        15: { guessCount: 6, won: false }, // 2026-03-03
+      }
+      localStorage.setItem('dailyHistory', JSON.stringify(legacyHistory))
+      localStorage.setItem('dailyHistoryStartIndex', '13')
+    })
+
+    await page.clock.setFixedTime(new Date('2026-03-10T06:00:00Z'))
+    await page.goto('/')
+    await waitForGameReady(page)
+
+    // Open calendar — should show March 2026
+    await page.locator('svg.h-6.w-6.cursor-pointer').nth(CALENDAR_ICON).click()
+    await expect(page.getByRole('heading', { name: 'Calendar' })).toBeVisible()
+
+    // Verify win/loss indicators rendered from migrated data
+    await expect(page.locator('.bg-green-500')).toHaveCount(2)
+    await expect(page.locator('.bg-green-500:has-text("2")')).toBeVisible()
+    await expect(page.locator('.bg-green-500:has-text("4")')).toBeVisible()
+    await expect(page.locator('.bg-purple-500')).toHaveCount(1)
+
+    await screenshot(page, '01-migrated-calendar')
+    await ctx.close()
+  })
+
+  test('already-migrated date-key data is not re-migrated', async ({ browser }) => {
+    const ctx = await browser.newContext()
+    const page = await ctx.newPage()
+    await addGameInitScript(page)
+
+    // Inject already-migrated format
+    await page.addInitScript(() => {
+      const history = {
+        '2026-03-01': { guessCount: 3, won: true },
+        '2026-03-02': { guessCount: 1, won: true },
+      }
+      localStorage.setItem('dailyHistory', JSON.stringify(history))
+      localStorage.setItem('dailyHistoryStartDate', '2026-03-01')
+    })
+
+    await page.clock.setFixedTime(new Date('2026-03-10T12:00:00'))
+    await page.goto('/')
+    await waitForGameReady(page)
+
+    // Data should remain unchanged
+    const data = await page.evaluate(() => {
+      const raw = localStorage.getItem('dailyHistory')
+      return raw ? JSON.parse(raw) : null
+    })
+
+    expect(data['2026-03-01']).toEqual({ guessCount: 3, won: true })
+    expect(data['2026-03-02']).toEqual({ guessCount: 1, won: true })
+    expect(Object.keys(data)).toHaveLength(2)
+
+    await ctx.close()
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
                 "react-i18next": "^11.15.4",
                 "react-router-dom": "^5.3.4",
                 "react-scripts": "5.0.0",
+                "temporal-polyfill": "^0.3.1",
                 "typescript": "^4.5.4",
                 "web-vitals": "^2.1.3"
             },
@@ -16042,6 +16043,19 @@
                 "node": ">=8"
             }
         },
+        "node_modules/temporal-polyfill": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.1.tgz",
+            "integrity": "sha512-3Ceqnjxa7nQ1VGRjehALmP9LdiJqalmoYh6o22s8skP+ZN6df1cTN/7h+p0k4v357pFsQN94gtJoxV6fqvlijA==",
+            "dependencies": {
+                "temporal-spec": "0.3.1"
+            }
+        },
+        "node_modules/temporal-spec": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
+            "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw=="
+        },
         "node_modules/tempy": {
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tempy/-/tempy-0.6.0.tgz",
@@ -29046,6 +29060,19 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-2.0.0.tgz",
             "integrity": "sha512-aoBAniQmmwtcKp/7BzsH8Cxzv8OL736p7v1ihGb5e9DJ9kTwGWHrQrVB5+lfVDzfGrdRzXch+ig7LHaY1JTOrg=="
+        },
+        "temporal-polyfill": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/temporal-polyfill/-/temporal-polyfill-0.3.1.tgz",
+            "integrity": "sha512-3Ceqnjxa7nQ1VGRjehALmP9LdiJqalmoYh6o22s8skP+ZN6df1cTN/7h+p0k4v357pFsQN94gtJoxV6fqvlijA==",
+            "requires": {
+                "temporal-spec": "0.3.1"
+            }
+        },
+        "temporal-spec": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/temporal-spec/-/temporal-spec-0.3.1.tgz",
+            "integrity": "sha512-B4TUhezh9knfSIMwt7RVggApDRJZo73uZdj8AacL2mZ8RP5KtLianh2MXxL06GN9ESYiIsiuoLQhgVfwe55Yhw=="
         },
         "tempy": {
             "version": "0.6.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
         "react-i18next": "^11.15.4",
         "react-router-dom": "^5.3.4",
         "react-scripts": "5.0.0",
+        "temporal-polyfill": "^0.3.1",
         "typescript": "^4.5.4",
         "web-vitals": "^2.1.3"
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -16,9 +16,14 @@ import { SettingsModal } from './components/modals/SettingsModal'
 import { StatsModal, GameMode } from './components/modals/StatsModal'
 import { TranslateModal } from './components/modals/TranslateModal'
 import { CalendarModal } from './components/modals/CalendarModal'
-import { isWordInWordList, isWinningWord, solutionIndex } from './lib/words'
+import { Temporal } from 'temporal-polyfill'
+import { isWordInWordList, isWinningWord } from './lib/words'
 import { addStatsForCompletedGame, loadStats } from './lib/stats'
-import { saveDailyResult, initDailyHistoryStartIndex } from './lib/dailyHistory'
+import {
+  saveDailyResult,
+  initDailyHistoryStartDate,
+  dateToKey,
+} from './lib/dailyHistory'
 import {
   loadGameStateFromLocalStorage,
   saveGameStateToLocalStorage,
@@ -112,12 +117,10 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
 
   useEffect(() => {
     if (isDaily) {
-      initDailyHistoryStartIndex(solutionIndex)
-      const now = new Date()
-      const yyyy = now.getUTCFullYear()
-      const mm = String(now.getUTCMonth() + 1).padStart(2, '0')
-      const dd = String(now.getUTCDate()).padStart(2, '0')
-      document.title = `Wor\u{1F517}dle Daily | ${yyyy}-${mm}-${dd}`
+      const today = Temporal.Now.plainDateISO()
+      const todayKey = dateToKey(today)
+      initDailyHistoryStartDate(todayKey)
+      document.title = `Wor\u{1F517}dle Daily | ${todayKey}`
     } else if (isCustom) {
       document.title = `Wor\u{1F517}dle Custom | ${questioner}`
     } else {
@@ -201,12 +204,14 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
       setCurrentGuess([])
       setGuesses([...guesses, fullGuess])
 
+      const todayKey = dateToKey(Temporal.Now.plainDateISO())
+
       if (winningWord) {
         if (isDaily || isCustom) {
           setStats(addStatsForCompletedGame(stats, guesses.length, statsKey))
         }
         if (isDaily) {
-          saveDailyResult(solutionIndex, guesses.length + 1, true)
+          saveDailyResult(todayKey, guesses.length + 1, true)
         }
         return setIsGameWon(true)
       }
@@ -221,7 +226,7 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
             setStats(addStatsForCompletedGame(stats, CONFIG.tries, statsKey))
           }
           if (isDaily) {
-            saveDailyResult(solutionIndex, CONFIG.tries, false)
+            saveDailyResult(todayKey, CONFIG.tries, false)
           }
           setIsGameLost(true)
           return
@@ -235,19 +240,13 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
           )
         }
         if (isDaily) {
-          saveDailyResult(solutionIndex, guesses.length + 1, false)
+          saveDailyResult(todayKey, guesses.length + 1, false)
         }
         setIsGameLost(true)
       }
     }
   }
-  const utcDateStr = (() => {
-    const n = new Date()
-    const y = n.getUTCFullYear()
-    const m = String(n.getUTCMonth() + 1).padStart(2, '0')
-    const d = String(n.getUTCDate()).padStart(2, '0')
-    return `${y}-${m}-${d}`
-  })()
+  const localDateStr = dateToKey(Temporal.Now.plainDateISO())
 
   let translateElement = <div></div>
   if (CONFIG.availableLangs.length > 1) {
@@ -266,7 +265,7 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
           <h1 className="text-xl font-bold">Wor&#x1F517;dle</h1>
           <p className="text-sm text-gray-500">
             {isDaily ? (
-              <>Daily | {utcDateStr}</>
+              <>Daily | {localDateStr}</>
             ) : isCustom ? (
               <>
                 <span className="text-green-500">Custom</span> | {questioner}

--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -1,3 +1,4 @@
+import { Temporal } from 'temporal-polyfill'
 import { useState } from 'react'
 import { ChevronLeftIcon, ChevronRightIcon, RefreshIcon } from '@heroicons/react/outline'
 import { useTranslation } from 'react-i18next'
@@ -6,10 +7,9 @@ import { GameStats } from '../../lib/localStorage'
 import {
   DayResult,
   loadDailyHistory,
-  dateToSolutionIndex,
-  solutionIndexToDate,
+  dateToKey,
   getMonthResults,
-  getDailyHistoryStartIndex,
+  getDailyHistoryStartDate,
 } from '../../lib/dailyHistory'
 import { shareCalendar } from '../../lib/share'
 import { CONFIG } from '../../constants/config'
@@ -26,14 +26,12 @@ type Props = {
 
 export const Calendar = ({ gameStats, handleShare, weekStartsOnMonday, excludeUrl }: Props) => {
   const { t } = useTranslation()
-  const now = new Date()
-  const currentUTCYear = now.getUTCFullYear()
-  const currentUTCMonth = now.getUTCMonth()
+  const today = Temporal.Now.plainDateISO()
 
-  const [year, setYear] = useState(currentUTCYear)
-  const [month, setMonth] = useState(currentUTCMonth)
+  const [year, setYear] = useState(today.year)
+  const [month, setMonth] = useState(today.month - 1) // 0-indexed for consistency
 
-  const epochDate = new Date(CONFIG.startDate)
+  const epoch = Temporal.PlainDate.from(CONFIG.startDate)
 
   const canGoBack = true
   const canGoForward = true
@@ -62,22 +60,19 @@ export const Calendar = ({ gameStats, handleShare, weekStartsOnMonday, excludeUr
   const history = loadDailyHistory()
 
   // Build calendar grid
-  const rawDayOfWeek = new Date(Date.UTC(year, month, 1)).getUTCDay() // 0=Sun
+  const firstDay = Temporal.PlainDate.from({
+    year,
+    month: month + 1,
+    day: 1,
+  })
+  const rawDayOfWeek = firstDay.dayOfWeek // 1=Mon, 7=Sun (ISO)
+  const sundayBasedDow = rawDayOfWeek === 7 ? 0 : rawDayOfWeek // 0=Sun
   const firstDayOfWeek = weekStartsOnMonday
-    ? (rawDayOfWeek + 6) % 7 // Mon=0, Tue=1, ..., Sun=6
-    : rawDayOfWeek
+    ? (sundayBasedDow + 6) % 7 // Mon=0, Tue=1, ..., Sun=6
+    : sundayBasedDow
   const daysInMonth = monthResults.length
-  const todayUTCDate = now.getUTCDate()
 
-  const epochSolutionIndex = dateToSolutionIndex(epochDate)
-  const historyStartIndex = getDailyHistoryStartIndex()
-
-  const calendarEpochDate = historyStartIndex !== null
-    ? solutionIndexToDate(historyStartIndex)
-    : null
-  const calendarEpochYear = calendarEpochDate?.getUTCFullYear() ?? null
-  const calendarEpochMonth = calendarEpochDate?.getUTCMonth() ?? null
-  const calendarEpochDay = calendarEpochDate?.getUTCDate() ?? null
+  const calendarStartDate = getDailyHistoryStartDate()
 
   type CellData = {
     day: number | null
@@ -105,19 +100,13 @@ export const Calendar = ({ gameStats, handleShare, weekStartsOnMonday, excludeUr
 
   // Day cells
   for (let d = 1; d <= daysInMonth; d++) {
-    const isToday =
-      year === currentUTCYear && month === currentUTCMonth && d === todayUTCDate
-    const isFuture =
-      year > currentUTCYear ||
-      (year === currentUTCYear && month > currentUTCMonth) ||
-      (year === currentUTCYear && month === currentUTCMonth && d > todayUTCDate)
-    const daySolutionIndex = dateToSolutionIndex(
-      new Date(Date.UTC(year, month, d))
-    )
-    const isBeforeEpoch = daySolutionIndex < epochSolutionIndex ||
-      (historyStartIndex !== null && daySolutionIndex < historyStartIndex)
-    const isCalendarEpoch =
-      year === calendarEpochYear && month === calendarEpochMonth && d === calendarEpochDay
+    const date = firstDay.with({ day: d })
+    const key = dateToKey(date)
+    const isToday = Temporal.PlainDate.compare(date, today) === 0
+    const isFuture = Temporal.PlainDate.compare(date, today) > 0
+    const isBeforeEpoch = Temporal.PlainDate.compare(date, epoch) < 0 ||
+      (calendarStartDate !== null && key < calendarStartDate)
+    const isCalendarEpoch = calendarStartDate === key
 
     cells.push({
       day: d,
@@ -142,10 +131,10 @@ export const Calendar = ({ gameStats, handleShare, weekStartsOnMonday, excludeUr
     })
   }
 
-  const monthLabel = new Date(Date.UTC(year, month, 1)).toLocaleDateString(
-    'en-US',
-    { year: 'numeric', month: 'long', timeZone: 'UTC' }
-  )
+  const monthLabel = firstDay.toLocaleString('en-US', {
+    year: 'numeric',
+    month: 'long',
+  })
 
   const fallbackWeekdays = weekStartsOnMonday ? WEEKDAYS_MON : WEEKDAYS_SUN
   const weekdayKeys = t('weekdays', { returnObjects: true }) as string[]
@@ -177,11 +166,11 @@ export const Calendar = ({ gameStats, handleShare, weekStartsOnMonday, excludeUr
         </span>
         <button
           onClick={() => {
-            setYear(currentUTCYear)
-            setMonth(currentUTCMonth)
+            setYear(today.year)
+            setMonth(today.month - 1)
           }}
-          disabled={year === currentUTCYear && month === currentUTCMonth}
-          className={`p-1 rounded ${year === currentUTCYear && month === currentUTCMonth ? 'opacity-30 cursor-default' : 'hover:bg-gray-100 cursor-pointer'}`}
+          disabled={year === today.year && month === today.month - 1}
+          className={`p-1 rounded ${year === today.year && month === today.month - 1 ? 'opacity-30 cursor-default' : 'hover:bg-gray-100 cursor-pointer'}`}
           title="Today"
         >
           <RefreshIcon className="h-5 w-5" />

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -16,7 +16,7 @@ export const CONFIG = {
   wordListSourceLink: 'https://www.nytimes.com/games/wordle',
   googleAnalytics: '',
   normalization: 'NFC',
-  startDate: 'February 16, 2026 00:00:00 UTC',
+  startDate: '2026-02-16',
   defaultLang: 'en',
   availableLangs: ['en', 'ko', 'ja', 'es', 'sw', 'zh'],
   escapeSpecialCharacters: true,

--- a/src/lib/dailyHistory.ts
+++ b/src/lib/dailyHistory.ts
@@ -1,3 +1,4 @@
+import { Temporal } from 'temporal-polyfill'
 import { CONFIG } from '../constants/config'
 
 export type DayResult = {
@@ -5,23 +6,26 @@ export type DayResult = {
   won: boolean
 }
 
-export type DailyHistory = Record<number, DayResult> // key = solutionIndex
+export type DailyHistory = Record<string, DayResult> // key = "yyyy-mm-dd"
 
 const STORAGE_KEY = 'dailyHistory'
-const START_INDEX_KEY = 'dailyHistoryStartIndex'
+const START_DATE_KEY = 'dailyHistoryStartDate'
+const LEGACY_START_INDEX_KEY = 'dailyHistoryStartIndex'
 
-export const getDailyHistoryStartIndex = (): number | null => {
-  const stored = localStorage.getItem(START_INDEX_KEY)
-  return stored !== null ? parseInt(stored, 10) : null
+export const dateToKey = (date: Temporal.PlainDate): string => date.toString()
+
+export const getDailyHistoryStartDate = (): string | null => {
+  return localStorage.getItem(START_DATE_KEY)
 }
 
-export const initDailyHistoryStartIndex = (currentIndex: number): void => {
-  if (localStorage.getItem(START_INDEX_KEY) === null) {
-    localStorage.setItem(START_INDEX_KEY, currentIndex.toString())
+export const initDailyHistoryStartDate = (dateKey: string): void => {
+  if (localStorage.getItem(START_DATE_KEY) === null) {
+    localStorage.setItem(START_DATE_KEY, dateKey)
   }
 }
 
 export const loadDailyHistory = (): DailyHistory => {
+  migrateDailyHistory()
   const data = localStorage.getItem(STORAGE_KEY)
   return data ? (JSON.parse(data) as DailyHistory) : {}
 }
@@ -31,31 +35,14 @@ export const saveDailyHistory = (history: DailyHistory): void => {
 }
 
 export const saveDailyResult = (
-  solutionIndex: number,
+  dateKey: string,
   guessCount: number,
   won: boolean
 ): void => {
   const history = loadDailyHistory()
-  if (history[solutionIndex]) return // prevent double-write
-  history[solutionIndex] = { guessCount, won }
+  if (history[dateKey]) return // prevent double-write
+  history[dateKey] = { guessCount, won }
   saveDailyHistory(history)
-}
-
-const MS_IN_DAY = 86400000
-
-export const solutionIndexToDate = (index: number): Date => {
-  const epochMs = new Date(CONFIG.startDate).valueOf()
-  return new Date(epochMs + index * MS_IN_DAY)
-}
-
-export const dateToSolutionIndex = (date: Date): number => {
-  const epochMs = new Date(CONFIG.startDate).valueOf()
-  const dayStart = Date.UTC(
-    date.getUTCFullYear(),
-    date.getUTCMonth(),
-    date.getUTCDate()
-  )
-  return Math.floor((dayStart - epochMs) / MS_IN_DAY)
 }
 
 export const getMonthResults = (
@@ -63,14 +50,58 @@ export const getMonthResults = (
   month: number // 0-indexed
 ): (DayResult | null)[] => {
   const history = loadDailyHistory()
-  const daysInMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate()
+  const firstDay = Temporal.PlainDate.from({
+    year,
+    month: month + 1, // Temporal uses 1-indexed months
+    day: 1,
+  })
+  const daysInMonth = firstDay.daysInMonth
   const results: (DayResult | null)[] = []
 
   for (let day = 1; day <= daysInMonth; day++) {
-    const date = new Date(Date.UTC(year, month, day))
-    const index = dateToSolutionIndex(date)
-    results.push(history[index] ?? null)
+    const date = firstDay.with({ day })
+    const key = dateToKey(date)
+    results.push(history[key] ?? null)
   }
 
   return results
+}
+
+// --- Migration: integer-key → date-string-key (one-time) ---
+
+let migrated = false
+
+const migrateDailyHistory = (): void => {
+  if (migrated) return
+  migrated = true
+
+  const raw = localStorage.getItem(STORAGE_KEY)
+  if (!raw) return
+
+  const parsed = JSON.parse(raw) as Record<string, DayResult>
+  const keys = Object.keys(parsed)
+  if (keys.length === 0) return
+
+  // If the first key looks like a date string, already migrated
+  if (keys[0].includes('-')) return
+
+  // Legacy format: keys are integer solutionIndex strings
+  const epoch = Temporal.PlainDate.from(CONFIG.startDate)
+  const newHistory: DailyHistory = {}
+
+  for (const key of keys) {
+    const index = parseInt(key, 10)
+    const date = epoch.add({ days: index })
+    newHistory[dateToKey(date)] = parsed[key]
+  }
+
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(newHistory))
+
+  // Migrate dailyHistoryStartIndex → dailyHistoryStartDate
+  const legacyStartIndex = localStorage.getItem(LEGACY_START_INDEX_KEY)
+  if (legacyStartIndex !== null) {
+    const startDate = epoch.add({ days: parseInt(legacyStartIndex, 10) })
+    localStorage.setItem(START_DATE_KEY, dateToKey(startDate))
+    localStorage.removeItem(LEGACY_START_INDEX_KEY)
+  }
 }

--- a/src/lib/dailyHistory.ts
+++ b/src/lib/dailyHistory.ts
@@ -19,6 +19,7 @@ export const getDailyHistoryStartDate = (): string | null => {
 }
 
 export const initDailyHistoryStartDate = (dateKey: string): void => {
+  migrateDailyHistory()
   if (localStorage.getItem(START_DATE_KEY) === null) {
     localStorage.setItem(START_DATE_KEY, dateKey)
   }

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -1,6 +1,7 @@
+import { Temporal } from 'temporal-polyfill'
 import { getGuessStatuses } from './statuses'
 import { CONFIG } from '../constants/config'
-import { DailyHistory, dateToSolutionIndex, getDailyHistoryStartIndex } from './dailyHistory'
+import { DailyHistory, dateToKey, getDailyHistoryStartDate } from './dailyHistory'
 
 export const shareCustomStatus = (
   guesses: string[][],
@@ -31,13 +32,10 @@ export const shareStatus = (
   solution: string,
   excludeUrl: boolean = false
 ) => {
-  const now = new Date()
-  const yyyy = now.getUTCFullYear()
-  const mm = String(now.getUTCMonth() + 1).padStart(2, '0')
-  const dd = String(now.getUTCDate()).padStart(2, '0')
+  const today = Temporal.Now.plainDateISO()
 
   const shareText =
-    `Wor\u{1F517}dle ${yyyy}-${mm}-${dd}` +
+    `Wor\u{1F517}dle ${today.toString()}` +
     ' ' +
     `${lost ? 'X' : guesses.length}` +
     '/' +
@@ -66,18 +64,20 @@ export const shareCalendar = (
   excludeUrl: boolean = false
 ) => {
   const mm = String(month + 1).padStart(2, '0')
-  const daysInMonth = new Date(Date.UTC(year, month + 1, 0)).getUTCDate()
+  const epoch = Temporal.PlainDate.from(CONFIG.startDate)
+  const today = Temporal.Now.plainDateISO()
+  const startDate = getDailyHistoryStartDate()
 
-  const now = new Date()
-  const todayYear = now.getUTCFullYear()
-  const todayMonth = now.getUTCMonth()
-  const todayDate = now.getUTCDate()
+  const firstDay = Temporal.PlainDate.from({
+    year,
+    month: month + 1,
+    day: 1,
+  })
+  const daysInMonth = firstDay.daysInMonth
 
-  const epochDate = new Date(CONFIG.startDate)
-  const epochIndex = dateToSolutionIndex(epochDate)
-  const historyStartIndex = getDailyHistoryStartIndex()
+  const isCurrentMonth =
+    year === today.year && month === today.month - 1
 
-  const isCurrentMonth = year === todayYear && month === todayMonth
   const lines: string[] = []
   const header = isCurrentMonth
     ? `Wor\u{1F517}dle ${year}-${mm} (\u{1F525} ${streak})`
@@ -90,21 +90,17 @@ export const shareCalendar = (
   let row: string[] = []
 
   for (let d = 1; d <= daysInMonth; d++) {
-    const date = new Date(Date.UTC(year, month, d))
-    const index = dateToSolutionIndex(date)
-    const isFuture =
-      year > todayYear ||
-      (year === todayYear && month > todayMonth) ||
-      (year === todayYear && month === todayMonth && d > todayDate)
-    const isBeforeEpoch = index < epochIndex
-
+    const date = firstDay.with({ day: d })
+    const key = dateToKey(date)
+    const isFuture = Temporal.PlainDate.compare(date, today) > 0
+    const isBeforeEpoch = Temporal.PlainDate.compare(date, epoch) < 0
     const isPreCalendarEpoch =
-      historyStartIndex !== null && index < historyStartIndex
+      startDate !== null && key < startDate
 
     if (isFuture || isBeforeEpoch || isPreCalendarEpoch) {
       row.push('⚪') // inactive (future / before epoch / pre-calendar)
     } else {
-      const result = dailyHistory[index]
+      const result = dailyHistory[key]
       if (!result) {
         row.push('⬜') // not played
       } else if (result.won) {

--- a/src/lib/words.ts
+++ b/src/lib/words.ts
@@ -1,3 +1,4 @@
+import { Temporal } from 'temporal-polyfill'
 import { WORDS } from '../constants/wordlist'
 import { VALIDGUESSES } from '../constants/validGuesses'
 import { CONFIG } from '../constants/config'
@@ -15,17 +16,19 @@ export const getRandomWord = () => {
 }
 
 export const getWordOfDay = () => {
-  // January 1, 2022 Game Epoch
-  const epochMs = new Date(CONFIG.startDate).valueOf()
-  const now = Date.now()
-  const msInDay = 86400000
-  const index = Math.floor((now - epochMs) / msInDay)
-  const nextday = (index + 1) * msInDay + epochMs
+  const epoch = Temporal.PlainDate.from(CONFIG.startDate)
+  const today = Temporal.Now.plainDateISO()
+  const index = today.since(epoch).days
+
+  const tz = Temporal.Now.timeZoneId()
+  const tomorrow = today
+    .add({ days: 1 })
+    .toZonedDateTime(tz).epochMilliseconds
 
   return {
     solution: WORDS[index % WORDS.length],
     solutionIndex: index,
-    tomorrow: nextday,
+    tomorrow,
   }
 }
 


### PR DESCRIPTION
## Summary

- **Temporal API (`temporal-polyfill`) 도입**: `Date` 객체를 완전히 제거하고 DST-safe한 `Temporal.PlainDate` 기반으로 전환
- **단어 갱신 기준 변경**: UTC 자정 → 디바이스 로컬 타임존 자정 (NYT Wordle 방식)
- **dailyHistory 마이그레이션**: 기존 정수 solutionIndex key → `"yyyy-mm-dd"` ISO 날짜 문자열 key (앱 로드 시 자동 1회 변환)
- **E2E 테스트 강화**: Playwright `clock.setFixedTime()` + `timezoneId`를 활용한 타임존별 검증 및 마이그레이션 검증

## Changes

### Core
- `words.ts`: `Temporal.Now.plainDateISO()` + `today.since(epoch).days`로 solutionIndex 계산
- `dailyHistory.ts`: `Record<string, DayResult>` (날짜 key), `migrateDailyHistory()` 자동 변환
- `config.ts`: `startDate`를 ISO 8601 형식(`'2026-02-16'`)으로 변경

### UI
- `App.tsx`: subtitle/title 날짜, `saveDailyResult()` 호출을 dateKey 기반으로 변경
- `Calendar.tsx`: `Temporal.PlainDate.compare()`로 today/future/epoch 판정
- `share.ts`: `Temporal.Now.plainDateISO()`로 공유 텍스트 날짜 생성

### Tests
- `calendar.spec.ts`: Date → Temporal 전환, 날짜 key 기반 injectHistory
- `local-timezone.spec.ts` (신규): 타임존별 단어 갱신 검증 3개 + 마이그레이션 검증 3개

## Test plan

- [x] 단위 테스트 통과 (`npm test`)
- [x] 전체 E2E 테스트 통과 (Chromium, WebKit, mobile — 246 passed)
- [x] 타임존 경계 테스트: 도쿄/뉴욕/LA에서 로컬 날짜 기준 동작 확인
- [x] 마이그레이션 테스트: 구버전 정수 key → 날짜 key 자동 변환 확인
- [ ] 수동 확인: `npm run build && npx serve -s build` → subtitle 날짜가 로컬 기준인지 확인

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)