### PR TITLE
ci: E2E 빌드 시 PUBLIC_URL 설정으로 서버 경로 불일치 수정 (#66)

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -32,8 +32,10 @@ jobs:
         run: npm ci
       - name: Install Playwright browsers
         run: npx playwright install --with-deps
-      - name: Build
+      - name: Build for E2E
         run: npm run build
+        env:
+          PUBLIC_URL: /
       - name: Run Playwright tests
         run: npx playwright test
       - uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- E2E 빌드 시 `PUBLIC_URL=/` 환경변수를 설정하여 정적 서버와의 경로 불일치 해결
- `package.json`의 `homepage`(`/Wor-chain-dle/`)로 인해 빌드 결과물의 JS/CSS 경로가 `/Wor-chain-dle/static/...`로 생성되었으나, E2E 서버(`serve`)는 `localhost:3000` 루트에서 서빙하여 404 발생 → React 앱 미마운트

## Context
Closes #66

이전 시도들(Docker, http-server 교체 등)에서 서버 크래시/타임아웃으로 실패했던 근본 원인이 `PUBLIC_URL` 불일치였음을 확인.

### 관련 PR
- #90 (실험: 조건 완화 + 단일 테스트로 원인 특정)

## Test plan
- [ ] release → main PR 시 e2e job이 트리거되는지 확인
- [ ] 전체 Playwright 테스트(4 프로젝트, 전체 스펙)가 통과하는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)