### PR TITLE
fix: 모달 타이틀 정렬 및 Bold 적용

### DIFF
--- a/src/components/modals/BaseModal.tsx
+++ b/src/components/modals/BaseModal.tsx
@@ -59,7 +59,7 @@ export const BaseModal = ({ title, children, isOpen, handleClose }: Props) => {
                 <div className="text-center">
                   <Dialog.Title
                     as="h3"
-                    className="text-lg leading-6 font-medium text-gray-900 pr-8"
+                    className="text-lg leading-6 font-bold text-gray-900 px-8"
                   >
                     {title}
                   </Dialog.Title>


### PR DESCRIPTION
Closes #83
Closes #84

## Summary
- 모달 타이틀의 좌우 패딩을 대칭으로 변경하여 (`pr-8` → `px-8`) 타이틀과 하위 콘텐츠의 중앙 정렬 불일치 수정
- 모달 타이틀 폰트 웨이트를 `font-medium` → `font-bold`로 변경하여 타이틀 임팩트 강화

## Test plan
- [x] PatchNotesModal에서 타이틀과 버전 뱃지의 수평 중심 정렬 확인
- [x] 모든 모달(Info, Stats, Settings, Calendar, Donate, Translate)에서 타이틀 Bold 적용 확인
- [x] 타이틀이 긴 모달(TranslateModal 등)에서 좌측 패딩으로 인한 레이아웃 깨짐 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)