### PR TITLE
fix: deploy 워크플로우에서 PR body의 쉘 injection 방지

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,15 +65,10 @@ jobs:
         id: version
         run: echo "version=v$(node -p "require('./package.json').version")" >> "$GITHUB_OUTPUT"
       - name: Get release PR body
-        id: pr
         env:
           GH_TOKEN: ${{ github.token }}
-        run: |
-          PR_BODY=$(gh pr list --state merged --base main --limit 1 --json body --jq '.[0].body')
-          echo "body<<EOF" >> "$GITHUB_OUTPUT"
-          echo "$PR_BODY" >> "$GITHUB_OUTPUT"
-          echo "EOF" >> "$GITHUB_OUTPUT"
+        run: gh pr list --state merged --base main --limit 1 --json body --jq '.[0].body' > release-notes.md
       - name: Create tag and release
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release create "${{ steps.version.outputs.version }}" --title "${{ steps.version.outputs.version }}" --notes "${{ steps.pr.outputs.body }}"
+        run: gh release create "${{ steps.version.outputs.version }}" --title "${{ steps.version.outputs.version }}" --notes-file release-notes.md


### PR DESCRIPTION
Closes #68

## Summary
- `gh release create`에서 PR body를 `--notes`로 직접 전달하면 백틱이 쉘 command substitution으로 실행되는 보안/안정성 문제 수정
- PR body를 파일(`release-notes.md`)로 저장한 뒤 `--notes-file`로 전달하는 방식으로 변경

## Test plan
- [ ] `release/v1.4.0` → `main` 머지 후 deploy 워크플로우에서 릴리스가 정상 생성되는지 확인
- [ ] 릴리스 본문에 PR body 내용이 그대로 포함되는지 확인 (백틱 등 특수문자 보존)

🤖 Generated with [Claude Code](https://claude.com/claude-code)