### PR TITLE
feat: 모달 타이틀 좌측에 컨텍스트 아이콘 추가

### DIFF
--- a/src/components/modals/BaseModal.tsx
+++ b/src/components/modals/BaseModal.tsx
@@ -4,14 +4,13 @@ import { XCircleIcon } from '@heroicons/react/outline'
 
 type Props = {
   title: string
+  icon?: React.ReactNode
   children: React.ReactNode
   isOpen: boolean
   handleClose: () => void
-  // guesses: string[][]
-  // handleShare: () => void
 }
 
-export const BaseModal = ({ title, children, isOpen, handleClose }: Props) => {
+export const BaseModal = ({ title, icon, children, isOpen, handleClose }: Props) => {
   return (
     <Transition.Root show={isOpen} as={Fragment}>
       <Dialog
@@ -49,7 +48,12 @@ export const BaseModal = ({ title, children, isOpen, handleClose }: Props) => {
             leaveTo="opacity-0 translate-y-4 sm:translate-y-0 sm:scale-95"
           >
             <div className="inline-block align-bottom bg-white rounded-lg px-4 pt-5 pb-4 text-left overflow-hidden shadow-xl transform transition-all sm:my-8 sm:align-middle w-full sm:max-w-md sm:p-6">
-              <div className="absolute right-4 top-4">
+              {icon && (
+                <div className="absolute left-4 top-5 sm:left-6 sm:top-6">
+                  <div className="h-6 w-6">{icon}</div>
+                </div>
+              )}
+              <div className="absolute right-4 top-5 sm:right-6 sm:top-6">
                 <XCircleIcon
                   className="h-6 w-6 cursor-pointer"
                   onClick={() => handleClose()}

--- a/src/components/modals/CalendarModal.tsx
+++ b/src/components/modals/CalendarModal.tsx
@@ -1,4 +1,5 @@
 import { BaseModal } from './BaseModal'
+import { CalendarIcon } from '@heroicons/react/outline'
 import { Calendar } from '../calendar/Calendar'
 import { GameStats } from '../../lib/localStorage'
 import { useTranslation } from 'react-i18next'
@@ -25,6 +26,7 @@ export const CalendarModal = ({
   return (
     <BaseModal
       title={t('calendar')}
+      icon={<CalendarIcon />}
       isOpen={isOpen}
       handleClose={handleClose}
     >

--- a/src/components/modals/DonateModal.tsx
+++ b/src/components/modals/DonateModal.tsx
@@ -1,5 +1,6 @@
 import { useState } from 'react'
 import { BaseModal } from './BaseModal'
+import { CurrencyDollarIcon } from '@heroicons/react/outline'
 import { useTranslation } from 'react-i18next'
 import {
   KAKAOPAY_PAYMENT_URL,
@@ -27,7 +28,7 @@ export const DonateModal = ({ isOpen, handleClose }: Props) => {
   const [activeTab, setActiveTab] = useState(TABS[0].id)
 
   return (
-    <BaseModal title={t('donate')} isOpen={isOpen} handleClose={handleClose}>
+    <BaseModal title={t('donate')} icon={<CurrencyDollarIcon />} isOpen={isOpen} handleClose={handleClose}>
       {TABS.length > 1 && (
         <div className="flex border-b border-gray-200 mb-4">
           {TABS.map((tab) => (

--- a/src/components/modals/InfoModal.tsx
+++ b/src/components/modals/InfoModal.tsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { Cell } from '../grid/Cell'
 import { ChainBridge } from '../grid/ChainBridge'
 import { BaseModal } from './BaseModal'
+import { InformationCircleIcon } from '@heroicons/react/outline'
 import { CONFIG } from '../../constants/config'
 import { Trans, useTranslation } from 'react-i18next'
 import 'i18next'
@@ -225,6 +226,7 @@ export const InfoModal = ({ isOpen, handleClose, mode, questioner }: Props) => {
   return (
     <BaseModal
       title={t('information')}
+      icon={<InformationCircleIcon />}
       isOpen={isOpen}
       handleClose={handleClose}
     >

--- a/src/components/modals/PatchNotesModal.tsx
+++ b/src/components/modals/PatchNotesModal.tsx
@@ -1,4 +1,5 @@
 import { BaseModal } from './BaseModal'
+import { SparklesIcon } from '@heroicons/react/outline'
 import { PATCH_NOTES_VERSION } from '../../constants/config'
 import { useTranslation } from 'react-i18next'
 
@@ -37,6 +38,7 @@ export const PatchNotesModal = ({ isOpen, handleClose }: Props) => {
   return (
     <BaseModal
       title={t('patchNotesTitle')}
+      icon={<SparklesIcon />}
       isOpen={isOpen}
       handleClose={handleClose}
     >

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -1,4 +1,5 @@
 import { BaseModal } from './BaseModal'
+import { CogIcon } from '@heroicons/react/outline'
 import { useTranslation } from 'react-i18next'
 
 type Props = {
@@ -49,7 +50,7 @@ export const SettingsModal = ({
   const { t } = useTranslation()
 
   return (
-    <BaseModal title={t('settings')} isOpen={isOpen} handleClose={handleClose}>
+    <BaseModal title={t('settings')} icon={<CogIcon />} isOpen={isOpen} handleClose={handleClose}>
       <div className="mt-2">
         <div className="flex items-center justify-between py-3">
           <span className="text-sm font-medium text-gray-700">

--- a/src/components/modals/StatsModal.tsx
+++ b/src/components/modals/StatsModal.tsx
@@ -5,6 +5,7 @@ import { GameStats } from '../../lib/localStorage'
 import { shareStatus, shareCustomStatus } from '../../lib/share'
 import { tomorrow } from '../../lib/words'
 import { BaseModal } from './BaseModal'
+import { ChartBarIcon } from '@heroicons/react/outline'
 import { useTranslation } from 'react-i18next'
 
 export type GameMode = 'daily' | 'practice' | 'custom'
@@ -42,6 +43,7 @@ export const StatsModal = ({
     return (
       <BaseModal
         title={t('statistics')}
+        icon={<ChartBarIcon />}
         isOpen={isOpen}
         handleClose={handleClose}
       >
@@ -64,6 +66,7 @@ export const StatsModal = ({
     return (
       <BaseModal
         title={t('statistics')}
+        icon={<ChartBarIcon />}
         isOpen={isOpen}
         handleClose={handleClose}
       >
@@ -109,6 +112,7 @@ export const StatsModal = ({
     return (
       <BaseModal
         title={t('statistics')}
+        icon={<ChartBarIcon />}
         isOpen={isOpen}
         handleClose={handleClose}
       >
@@ -119,6 +123,7 @@ export const StatsModal = ({
   return (
     <BaseModal
       title={t('statistics')}
+      icon={<ChartBarIcon />}
       isOpen={isOpen}
       handleClose={handleClose}
     >

--- a/src/components/modals/TranslateModal.tsx
+++ b/src/components/modals/TranslateModal.tsx
@@ -1,4 +1,5 @@
 import { BaseModal } from './BaseModal'
+import { TranslateIcon } from '@heroicons/react/outline'
 import { CONFIG } from '../../constants/config'
 import { useTranslation } from 'react-i18next'
 import { localeLanguageKey } from '../../i18n'
@@ -45,6 +46,7 @@ export const TranslateModal = ({ isOpen, handleClose }: Props) => {
   return (
     <BaseModal
       title={t('pickYourLanguage')}
+      icon={<TranslateIcon />}
       isOpen={isOpen}
       handleClose={handleClose}
     >


### PR DESCRIPTION
## Summary
- BaseModal에 `icon` prop 추가, 타이틀 왼쪽에 X 버튼과 대칭으로 아이콘 배치
- 각 모달에 해당 모달을 여는 버튼과 동일한 heroicon 전달 (Settings→CogIcon, Calendar→CalendarIcon, Info→InformationCircleIcon, Stats→ChartBarIcon, Donate→CurrencyDollarIcon, Translate→TranslateIcon, PatchNotes→SparklesIcon)
- 아이콘/X 버튼 위치를 모달 패딩(pt-5/sm:p-6)에 맞춰 수직 정렬 보정

## Test plan
- [ ] 로컬에서 각 모달을 열어 좌측 아이콘이 X 버튼과 좌우 대칭인지 확인
- [ ] 타이틀 텍스트가 가운데 정렬 유지되는지 확인
- [ ] 모바일 뷰포트에서 레이아웃 깨지지 않는지 확인
- [ ] Practice 모드 StatsModal 등 icon 없이 열리는 케이스가 없는지 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)