### PR TITLE
feat: 후원 모달에 GitHub Sponsors 탭 추가 (#40)

### DIFF
--- a/src/components/modals/DonateModal.tsx
+++ b/src/components/modals/DonateModal.tsx
@@ -48,19 +48,21 @@ export const DonateModal = ({ isOpen, handleClose }: Props) => {
         </div>
       )}
 
-      <div className="min-h-[280px]">
+      <div className="h-[21rem]">
         {activeTab === 'kakaopay' && (
-          <div className="flex flex-col items-center">
-            <img
-              src={process.env.PUBLIC_URL + '/images/kakaopay-qr.png'}
-              alt="KakaoPay QR"
-              className="w-48 mb-3"
-            />
+          <div className="flex flex-col items-center justify-center h-full">
+            <div className="flex items-center justify-center h-48 mb-3">
+              <img
+                src={process.env.PUBLIC_URL + '/images/kakaopay-qr.png'}
+                alt="KakaoPay QR"
+                className="w-48"
+              />
+            </div>
             <a
               href={KAKAOPAY_PAYMENT_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center px-6 py-3 mb-3 text-base font-medium rounded-md text-gray-900 bg-yellow-400 hover:bg-yellow-500 shadow-sm focus:outline-none"
+              className="inline-flex items-center justify-center min-w-[14rem] px-6 py-3 mb-3 text-base font-medium rounded-md text-gray-900 bg-yellow-400 hover:bg-yellow-500 shadow-sm focus:outline-none"
             >
               {t('donateKakaoPay')}
             </a>
@@ -71,15 +73,17 @@ export const DonateModal = ({ isOpen, handleClose }: Props) => {
         )}
 
         {activeTab === 'toss' && (
-          <div className="flex flex-col items-center">
-            <img
-              src={process.env.PUBLIC_URL + '/images/toss-qr.jpg'}
-              alt="Toss QR"
-              className="w-48 mb-3"
-            />
+          <div className="flex flex-col items-center justify-center h-full">
+            <div className="flex items-center justify-center h-48 mb-3">
+              <img
+                src={process.env.PUBLIC_URL + '/images/toss-qr.jpg'}
+                alt="Toss QR"
+                className="w-48"
+              />
+            </div>
             <a
               href={TOSS_PAYMENT_URL}
-              className="inline-flex items-center px-6 py-3 mb-3 text-base font-medium rounded-md text-white bg-blue-500 hover:bg-blue-600 shadow-sm focus:outline-none"
+              className="inline-flex items-center justify-center min-w-[14rem] px-6 py-3 mb-3 text-base font-medium rounded-md text-white bg-blue-500 hover:bg-blue-600 shadow-sm focus:outline-none"
             >
               {t('donateToss')}
             </a>
@@ -90,19 +94,20 @@ export const DonateModal = ({ isOpen, handleClose }: Props) => {
         )}
 
         {activeTab === 'github' && (
-          <div className="flex flex-col items-center">
-            <iframe
-              src="https://github.com/sponsors/Ootzk/card"
-              title="Sponsor Ootzk"
-              height="225"
-              className="w-full max-w-[600px] mb-3"
-              style={{ border: 0 }}
-            />
+          <div className="flex flex-col items-center justify-center h-full">
+            <div className="flex items-center justify-center w-full h-48 mb-3">
+              <iframe
+                src="https://github.com/sponsors/Ootzk/card"
+                title="Sponsor Ootzk"
+                className="w-full h-full"
+                style={{ border: 0 }}
+              />
+            </div>
             <a
               href={GITHUB_SPONSORS_URL}
               target="_blank"
               rel="noopener noreferrer"
-              className="inline-flex items-center px-6 py-3 mb-3 text-base font-medium rounded-md text-white bg-gray-800 hover:bg-gray-900 shadow-sm focus:outline-none"
+              className="inline-flex items-center justify-center min-w-[14rem] px-6 py-3 mb-3 text-base font-medium rounded-md text-white bg-gray-800 hover:bg-gray-900 shadow-sm focus:outline-none"
             >
               {t('donateGithub')}
             </a>

--- a/src/components/modals/DonateModal.tsx
+++ b/src/components/modals/DonateModal.tsx
@@ -5,6 +5,7 @@ import { useTranslation } from 'react-i18next'
 import {
   KAKAOPAY_PAYMENT_URL,
   TOSS_PAYMENT_URL,
+  GITHUB_SPONSORS_URL,
 } from '../../constants/config'
 
 type Tab = {
@@ -15,7 +16,7 @@ type Tab = {
 const TABS: Tab[] = [
   { id: 'kakaopay', label: 'KakaoPay' },
   { id: 'toss', label: 'Toss' },
-  // { id: 'github', label: 'GitHub Sponsors' },
+  { id: 'github', label: 'GitHub' },
 ]
 
 type Props = {
@@ -81,6 +82,29 @@ export const DonateModal = ({ isOpen, handleClose }: Props) => {
               className="inline-flex items-center px-6 py-3 mb-3 text-base font-medium rounded-md text-white bg-blue-500 hover:bg-blue-600 shadow-sm focus:outline-none"
             >
               {t('donateToss')}
+            </a>
+            <p className="text-sm font-medium text-gray-700">
+              {t('donateMonsterDrink')}
+            </p>
+          </div>
+        )}
+
+        {activeTab === 'github' && (
+          <div className="flex flex-col items-center">
+            <iframe
+              src="https://github.com/sponsors/Ootzk/card"
+              title="Sponsor Ootzk"
+              height="225"
+              className="w-full max-w-[600px] mb-3"
+              style={{ border: 0 }}
+            />
+            <a
+              href={GITHUB_SPONSORS_URL}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center px-6 py-3 mb-3 text-base font-medium rounded-md text-white bg-gray-800 hover:bg-gray-900 shadow-sm focus:outline-none"
+            >
+              {t('donateGithub')}
             </a>
             <p className="text-sm font-medium text-gray-700">
               {t('donateMonsterDrink')}

--- a/src/constants/config.ts
+++ b/src/constants/config.ts
@@ -6,6 +6,8 @@ export const KAKAOPAY_PAYMENT_URL =
 export const TOSS_PAYMENT_URL =
   'supertoss://send?bank=%EC%B9%B4%EC%B9%B4%EC%98%A4%EB%B1%85%ED%81%AC&accountNo=3333260839723&amount=2100'
 
+export const GITHUB_SPONSORS_URL = 'https://github.com/sponsors/Ootzk'
+
 export const CONFIG = {
   tries: 6,
   language: 'English',

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -37,6 +37,7 @@
     "donateMonsterDrink": "Buy the developer a Monster Energy!",
     "donateKakaoPay": "Donate via KakaoPay",
     "donateToss": "Donate via Toss",
+    "donateGithub": "Donate via GitHub",
     "practice": "Practice",
     "daily": "Daily",
     "createPuzzleNav": "Create",
@@ -163,6 +164,8 @@
     "patchNote_settings_desc": "Added toggles for starting the week on Monday and excluding URL when sharing.",
     "patchNote_i18nFix_title": "Bug Fix",
     "patchNote_i18nFix_desc": "Fixed an issue where translation keys were briefly shown instead of text when opening the app in a background tab.",
+    "patchNote_sponsors_title": "GitHub Sponsors",
+    "patchNote_sponsors_desc": "You can now donate via GitHub Sponsors in the donation menu.",
     "languages": {
         "en": "English",
         "ko": "한국어",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -33,6 +33,7 @@
   "donateMonsterDrink": "¡Cómprale una lata de Monster Energy al desarrollador!",
   "donateKakaoPay": "Donar con KakaoPay",
   "donateToss": "Donar con Toss",
+  "donateGithub": "Donar con GitHub",
   "practice": "Práctica",
   "daily": "Diario",
   "createPuzzleNav": "Crear",
@@ -158,6 +159,8 @@
   "patchNote_settings_desc": "Se añadieron opciones para empezar la semana el lunes y excluir la URL al compartir.",
   "patchNote_i18nFix_title": "Corrección de error",
   "patchNote_i18nFix_desc": "Se corrigió un problema donde las claves de traducción aparecían brevemente en lugar del texto al abrir la app en una pestaña en segundo plano.",
+  "patchNote_sponsors_title": "GitHub Sponsors",
+  "patchNote_sponsors_desc": "Ahora puedes donar a través de GitHub Sponsors en el menú de donaciones.",
   "languages": {
     "en": "English",
     "ko": "한국어",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -37,6 +37,7 @@
     "donateMonsterDrink": "開発者にモンスターエナジーを1本おごってください！",
     "donateKakaoPay": "KakaoPayで寄付",
     "donateToss": "Tossで寄付",
+    "donateGithub": "GitHubで寄付",
     "practice": "練習",
     "daily": "今日の問題",
     "createPuzzleNav": "出題",
@@ -117,6 +118,8 @@
     "patchNote_settings_desc": "週の始まりを月曜日に変更、共有時にURLを除外するトグルが追加されました。",
     "patchNote_i18nFix_title": "バグ修正",
     "patchNote_i18nFix_desc": "バックグラウンドタブでアプリを開いた際に翻訳キーが一瞬表示される問題を修正しました。",
+    "patchNote_sponsors_title": "GitHub Sponsors",
+    "patchNote_sponsors_desc": "寄付メニューからGitHub Sponsorsで寄付できるようになりました。",
     "languages": {
         "en": "English",
         "ko": "한국어",

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -37,6 +37,7 @@
     "donateMonsterDrink": "개발자에게 몬스터 에너지 한 캔 사주세요!",
     "donateKakaoPay": "카카오페이로 후원",
     "donateToss": "토스로 후원",
+    "donateGithub": "GitHub으로 후원",
     "practice": "연습",
     "daily": "오늘의 문제",
     "createPuzzleNav": "출제",
@@ -117,6 +118,8 @@
     "patchNote_settings_desc": "주 시작 요일(월요일) 변경, 공유 시 URL 제외 토글이 추가되었습니다.",
     "patchNote_i18nFix_title": "버그 수정",
     "patchNote_i18nFix_desc": "백그라운드 탭에서 앱을 열 때 번역 키가 잠시 노출되던 문제를 수정했습니다.",
+    "patchNote_sponsors_title": "GitHub Sponsors",
+    "patchNote_sponsors_desc": "후원 메뉴에서 GitHub Sponsors로 후원할 수 있습니다.",
     "languages": {
         "en": "English",
         "ko": "한국어",

--- a/src/locales/sw/translation.json
+++ b/src/locales/sw/translation.json
@@ -33,6 +33,7 @@
   "donateMonsterDrink": "Mnunulie msanidi kopo la Monster Energy!",
   "donateKakaoPay": "Changia kupitia KakaoPay",
   "donateToss": "Changia kupitia Toss",
+  "donateGithub": "Changia kupitia GitHub",
   "practice": "Mazoezi",
   "daily": "Kila siku",
   "createPuzzleNav": "Unda",
@@ -158,6 +159,8 @@
   "patchNote_settings_desc": "Vibadilishaji vya kuanza wiki siku ya Jumatatu na kuondoa URL wakati wa kushiriki vimeongezwa.",
   "patchNote_i18nFix_title": "Utatuzi wa Hitilafu",
   "patchNote_i18nFix_desc": "Imetatuliwa tatizo ambapo funguo za tafsiri zilionekana kwa muda mfupi badala ya maandishi wakati wa kufungua programu kwenye kichupo cha nyuma.",
+  "patchNote_sponsors_title": "GitHub Sponsors",
+  "patchNote_sponsors_desc": "Sasa unaweza kuchangia kupitia GitHub Sponsors kwenye menyu ya michango.",
   "languages": {
     "en": "English",
     "ko": "한국어",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -33,6 +33,7 @@
   "donateMonsterDrink": "请给开发者买一罐Monster Energy！",
   "donateKakaoPay": "通过KakaoPay捐赠",
   "donateToss": "通过Toss捐赠",
+  "donateGithub": "通过 GitHub 捐赠",
   "practice": "練習",
   "daily": "每日挑戰",
   "createPuzzleNav": "出题",
@@ -157,6 +158,8 @@
   "patchNote_settings_desc": "新增了以周一作为每周起始日和分享时排除URL的开关。",
   "patchNote_i18nFix_title": "错误修复",
   "patchNote_i18nFix_desc": "修复了在后台标签页打开应用时翻译键短暂显示的问题。",
+  "patchNote_sponsors_title": "GitHub Sponsors",
+  "patchNote_sponsors_desc": "现在可以通过捐赠菜单中的 GitHub Sponsors 进行捐赠。",
   "languages": {
     "en": "English",
     "ko": "한국어",


### PR DESCRIPTION
Closes #40

## Summary
- 후원 모달에 GitHub Sponsors 탭 추가 (KakaoPay / Toss / GitHub 3탭 구성)
- GitHub 공식 Sponsor card iframe을 QR 이미지 대신 활용
- 해외 사용자를 위한 결제 수단 확보
- 탭 전환 시 모달 크기 고정 (고정 높이, 버튼/이미지 영역 통일)
- 6개 언어 번역 키 추가 (donateGithub, patchNote_sponsors)

## Test plan
- [ ] 후원 모달에서 KakaoPay / Toss / GitHub 탭 전환 시 모달 크기 일정 확인
- [ ] GitHub 탭에서 Sponsor card iframe 정상 렌더링 확인
- [ ] "Donate via GitHub" 버튼 클릭 시 https://github.com/sponsors/Ootzk 새 탭 열림 확인
- [ ] 모바일 뷰포트에서 iframe 반응형 확인
- [ ] 언어 전환 시 번역 키 정상 표시 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)