### PR TITLE
test: 후원 모달 E2E 테스트에 GitHub Sponsors 탭 검증 추가

### DIFF
--- a/e2e/modals.spec.ts
+++ b/e2e/modals.spec.ts
@@ -216,6 +216,16 @@ test.describe('Modals', () => {
     await expect(gamePage.locator('a:has-text("Donate via Toss")')).toBeVisible()
     await screenshot(gamePage, '02-donate-modal-toss')
 
+    // Switch to GitHub tab
+    await gamePage.locator('button:has-text("GitHub")').click()
+    await expect(gamePage.locator('iframe[title="Sponsor Ootzk"]')).toBeVisible()
+    await expect(gamePage.locator('a:has-text("Donate via GitHub")')).toBeVisible()
+    await expect(gamePage.locator('a:has-text("Donate via GitHub")')).toHaveAttribute(
+      'href',
+      'https://github.com/sponsors/Ootzk'
+    )
+    await screenshot(gamePage, '03-donate-modal-github')
+
     // Close
     await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
     await expect(gamePage.locator('h3:has-text("Donate")')).not.toBeVisible()


### PR DESCRIPTION
## Summary
- 후원 모달 E2E 테스트에 GitHub Sponsors 탭 전환 및 검증 시나리오 추가
- iframe 존재, 링크 텍스트, href 속성 검증

## Test plan
- [x] `npx playwright test e2e/modals.spec.ts -g "donate modal" --project="chromium"` 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)