### PR TITLE
feat: Records 모달 Achievements 탭 UI (#109)

### DIFF
--- a/src/components/achievements/AchievementList.tsx
+++ b/src/components/achievements/AchievementList.tsx
@@ -36,7 +36,7 @@ export const AchievementList = () => {
         >
           <div className="flex items-start justify-between">
             <div className="flex items-center gap-2 min-w-0">
-              <span className="text-lg flex-shrink-0">
+              <span className="text-lg flex-shrink-0 w-7 text-center inline-block">
                 {CATEGORY_ICONS[achievement.category]}
               </span>
               <span className="text-sm font-semibold truncate text-gray-900">
@@ -45,7 +45,7 @@ export const AchievementList = () => {
             </div>
             <DifficultyStars difficulty={achievement.difficulty} />
           </div>
-          <p className="text-xs mt-1 ml-8 text-gray-600">
+          <p className="text-xs mt-1 text-gray-600 text-left">
             {t(achievement.descriptionKey)}
           </p>
         </div>

--- a/src/components/achievements/AchievementList.tsx
+++ b/src/components/achievements/AchievementList.tsx
@@ -11,11 +11,10 @@ const CATEGORY_ICONS: Record<AchievementCategory, string> = {
 }
 
 const DifficultyStars = ({ difficulty }: { difficulty: number }) => {
-  const stars = Math.ceil(difficulty / 2)
   return (
     <span className="text-xs text-yellow-500 whitespace-nowrap">
-      {'★'.repeat(stars)}
-      {'☆'.repeat(5 - stars)}
+      {'★'.repeat(difficulty)}
+      {'☆'.repeat(10 - difficulty)}
     </span>
   )
 }

--- a/src/components/achievements/AchievementList.tsx
+++ b/src/components/achievements/AchievementList.tsx
@@ -1,0 +1,80 @@
+import { useTranslation } from 'react-i18next'
+import {
+  getAchievementsWithStatus,
+  AchievementCategory,
+} from '../../lib/achievements'
+
+const CATEGORY_ICONS: Record<AchievementCategory, string> = {
+  milestone: '\uD83C\uDFAF',
+  guess: '\uD83C\uDFB2',
+  streak: '\uD83D\uDD25',
+}
+
+const DifficultyStars = ({ difficulty }: { difficulty: number }) => {
+  const stars = Math.ceil(difficulty / 2)
+  return (
+    <span className="text-xs text-yellow-500 whitespace-nowrap">
+      {'★'.repeat(stars)}
+      {'☆'.repeat(5 - stars)}
+    </span>
+  )
+}
+
+export const AchievementList = () => {
+  const { t } = useTranslation()
+  const achievements = getAchievementsWithStatus()
+
+  return (
+    <div className="h-full overflow-y-auto space-y-2 pr-1">
+      {achievements.map((achievement) => (
+        <div
+          key={achievement.id}
+          className={`rounded-lg border p-3 ${
+            achievement.unlocked
+              ? 'border-indigo-200 bg-indigo-50'
+              : 'border-gray-200 bg-gray-50 opacity-50'
+          }`}
+        >
+          <div className="flex items-start justify-between">
+            <div className="flex items-center gap-2 min-w-0">
+              <span className="text-lg flex-shrink-0">
+                {CATEGORY_ICONS[achievement.category]}
+              </span>
+              <span
+                className={`text-sm font-semibold truncate ${
+                  achievement.unlocked ? 'text-gray-900' : 'text-gray-400'
+                }`}
+              >
+                {t(achievement.titleKey)}
+              </span>
+            </div>
+            <DifficultyStars difficulty={achievement.difficulty} />
+          </div>
+          <p
+            className={`text-xs mt-1 ml-8 ${
+              achievement.unlocked ? 'text-gray-600' : 'text-gray-400'
+            }`}
+          >
+            {t(achievement.descriptionKey)}
+          </p>
+          <div className="text-xs mt-1 ml-8">
+            {achievement.unlocked ? (
+              <span className="text-indigo-600">
+                {'\uD83D\uDD13'} {t('unlocked')}
+                {achievement.unlockedAt && (
+                  <span className="text-gray-400 ml-1">
+                    {new Date(achievement.unlockedAt).toLocaleDateString()}
+                  </span>
+                )}
+              </span>
+            ) : (
+              <span className="text-gray-400">
+                {'\uD83D\uDD12'} {t('locked')}
+              </span>
+            )}
+          </div>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/components/achievements/AchievementList.tsx
+++ b/src/components/achievements/AchievementList.tsx
@@ -31,8 +31,8 @@ export const AchievementList = () => {
           key={achievement.id}
           className={`rounded-lg border p-3 ${
             achievement.unlocked
-              ? 'border-indigo-200 bg-indigo-50'
-              : 'border-gray-200 bg-gray-50 opacity-50'
+              ? 'border-green-400 bg-green-50'
+              : 'border-gray-200'
           }`}
         >
           <div className="flex items-start justify-between">
@@ -40,39 +40,15 @@ export const AchievementList = () => {
               <span className="text-lg flex-shrink-0">
                 {CATEGORY_ICONS[achievement.category]}
               </span>
-              <span
-                className={`text-sm font-semibold truncate ${
-                  achievement.unlocked ? 'text-gray-900' : 'text-gray-400'
-                }`}
-              >
+              <span className="text-sm font-semibold truncate text-gray-900">
                 {t(achievement.titleKey)}
               </span>
             </div>
             <DifficultyStars difficulty={achievement.difficulty} />
           </div>
-          <p
-            className={`text-xs mt-1 ml-8 ${
-              achievement.unlocked ? 'text-gray-600' : 'text-gray-400'
-            }`}
-          >
+          <p className="text-xs mt-1 ml-8 text-gray-600">
             {t(achievement.descriptionKey)}
           </p>
-          <div className="text-xs mt-1 ml-8">
-            {achievement.unlocked ? (
-              <span className="text-indigo-600">
-                {'\uD83D\uDD13'} {t('unlocked')}
-                {achievement.unlockedAt && (
-                  <span className="text-gray-400 ml-1">
-                    {new Date(achievement.unlockedAt).toLocaleDateString()}
-                  </span>
-                )}
-              </span>
-            ) : (
-              <span className="text-gray-400">
-                {'\uD83D\uDD12'} {t('locked')}
-              </span>
-            )}
-          </div>
         </div>
       ))}
     </div>

--- a/src/components/modals/StatsModal.tsx
+++ b/src/components/modals/StatsModal.tsx
@@ -3,6 +3,7 @@ import Countdown from 'react-countdown'
 import { StatBar } from '../stats/StatBar'
 import { Histogram } from '../stats/Histogram'
 import { Calendar } from '../calendar/Calendar'
+import { AchievementList } from '../achievements/AchievementList'
 import { GameStats } from '../../lib/localStorage'
 import { shareStatus, shareCustomStatus } from '../../lib/share'
 import { encodeCustomPuzzle } from '../../lib/customPuzzle'
@@ -45,7 +46,9 @@ export const StatsModal = ({
   weekStartsOnMonday,
 }: Props) => {
   const { t } = useTranslation()
-  const [activeTab, setActiveTab] = useState<'stats' | 'calendar'>('stats')
+  const [activeTab, setActiveTab] = useState<
+    'stats' | 'calendar' | 'achievements'
+  >('stats')
 
   useEffect(() => {
     if (isOpen) setActiveTab('stats')
@@ -129,6 +132,7 @@ export const StatsModal = ({
   const tabs = [
     { id: 'stats' as const, label: t('statistics') },
     { id: 'calendar' as const, label: t('calendar') },
+    { id: 'achievements' as const, label: t('achievements') },
   ]
 
   return (
@@ -205,6 +209,8 @@ export const StatsModal = ({
             excludeUrl={excludeUrl}
           />
         )}
+
+        {activeTab === 'achievements' && <AchievementList />}
       </div>
     </BaseModal>
   )

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -172,6 +172,9 @@
         "sw": "Kiswahili",
         "zh": "中文"
     },
+    "achievements": "Achievements",
+    "unlocked": "Unlocked",
+    "locked": "Locked",
     "achievement_win_in_1_title": "One Shot!",
     "achievement_win_in_1_desc": "Win a game on the first guess",
     "achievement_win_in_2_title": "Double Tap",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -167,6 +167,9 @@
     "sw": "Kiswahili",
     "zh": "中文"
   },
+  "achievements": "Logros",
+  "unlocked": "Desbloqueado",
+  "locked": "Bloqueado",
   "achievement_win_in_1_title": "¡De un tiro!",
   "achievement_win_in_1_desc": "Acertar en el primer intento",
   "achievement_win_in_2_title": "Doble toque",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -126,6 +126,9 @@
         "sw": "Kiswahili",
         "zh": "中文"
     },
+    "achievements": "実績",
+    "unlocked": "解除済み",
+    "locked": "未解除",
     "achievement_win_in_1_title": "一発正解！",
     "achievement_win_in_1_desc": "1回目で正解する",
     "achievement_win_in_2_title": "ダブルタップ",

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -126,6 +126,9 @@
         "sw": "Kiswahili",
         "zh": "中文"
     },
+    "achievements": "업적",
+    "unlocked": "해금됨",
+    "locked": "미해금",
     "achievement_win_in_1_title": "한 방에!",
     "achievement_win_in_1_desc": "첫 번째 시도에서 정답을 맞추세요",
     "achievement_win_in_2_title": "두 번이면 충분해",

--- a/src/locales/sw/translation.json
+++ b/src/locales/sw/translation.json
@@ -167,6 +167,9 @@
     "sw": "Kiswahili",
     "zh": "中文"
   },
+  "achievements": "Mafanikio",
+  "unlocked": "Imefunguliwa",
+  "locked": "Imefungwa",
   "achievement_win_in_1_title": "Risasi moja!",
   "achievement_win_in_1_desc": "Shinda katika jaribio la kwanza",
   "achievement_win_in_2_title": "Mguso maradufu",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -166,6 +166,9 @@
     "sw": "Kiswahili",
     "zh": "中文"
   },
+  "achievements": "成就",
+  "unlocked": "已解锁",
+  "locked": "未解锁",
   "achievement_win_in_1_title": "一击即中！",
   "achievement_win_in_1_desc": "第1次尝试就猜对",
   "achievement_win_in_2_title": "双击命中",


### PR DESCRIPTION
## Summary

- Records 모달에 Achievements 탭 추가 (Statistics | Calendar | Achievements 3탭)
- 업적 카드 리스트: 카테고리 이모지(🎯🎲🔥), 난이도 별(★/☆ 10개), 해금 상태
- 해금 시 초록 하이라이트, 미해금 시 기본 테두리
- 6개 언어 i18n 키 추가 (achievements, unlocked, locked)

Closes #109

## Test plan

- [x] `CI=true npm run build` 통과
- [x] `npm test` 통과
- [x] localStorage로 해금 상태 시뮬레이션 후 UI 확인
- [ ] 모바일 레이아웃 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)