### PR TITLE
feat: Cosmetics 시스템 코어 + Share 이모지 치장품 (#107)

### DIFF
--- a/src/lib/achievements.ts
+++ b/src/lib/achievements.ts
@@ -46,6 +46,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     titleKey: 'achievement_play_10_title',
     descriptionKey: 'achievement_play_10_desc',
     progress: ({ stats }) => ({ current: stats.totalGames, target: 10 }),
+    rewardId: 'emoji_circle',
   },
   {
     id: 'play_50',
@@ -122,6 +123,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     titleKey: 'achievement_streak_3_title',
     descriptionKey: 'achievement_streak_3_desc',
     progress: ({ stats }) => ({ current: stats.bestStreak, target: 3 }),
+    rewardId: 'emoji_heart',
   },
   {
     id: 'streak_7',

--- a/src/lib/cosmetics.ts
+++ b/src/lib/cosmetics.ts
@@ -1,0 +1,102 @@
+// --- Type Definitions ---
+
+export type CosmeticCategory = 'shareEmoji' // 향후 'font' | 'cellColor' | 'chain' | 'endMessage' 추가
+
+export type ShareEmojiSet = {
+  correct: string
+  present: string
+  absent: string
+}
+
+export type CosmeticOption = {
+  id: string
+  category: CosmeticCategory
+  titleKey: string
+  requiresAchievement?: string
+}
+
+type CosmeticState = {
+  equipped: Record<CosmeticCategory, string>
+}
+
+// --- Share Emoji Options ---
+
+const SHARE_EMOJI_SETS: Record<string, ShareEmojiSet> = {
+  emoji_default: {
+    correct: '\uD83D\uDFE9',
+    present: '\uD83D\uDFEA',
+    absent: '\u2B1C',
+  },
+  emoji_circle: {
+    correct: '\uD83D\uDFE2',
+    present: '\uD83D\uDFE3',
+    absent: '\u26AA',
+  },
+  emoji_heart: {
+    correct: '\uD83D\uDC9A',
+    present: '\uD83D\uDC9C',
+    absent: '\uD83E\uDD0D',
+  },
+}
+
+export const COSMETIC_OPTIONS: CosmeticOption[] = [
+  {
+    id: 'emoji_default',
+    category: 'shareEmoji',
+    titleKey: 'cosmetic_emoji_default',
+  },
+  {
+    id: 'emoji_circle',
+    category: 'shareEmoji',
+    titleKey: 'cosmetic_emoji_circle',
+    requiresAchievement: 'play_10',
+  },
+  {
+    id: 'emoji_heart',
+    category: 'shareEmoji',
+    titleKey: 'cosmetic_emoji_heart',
+    requiresAchievement: 'streak_3',
+  },
+]
+
+// --- localStorage ---
+
+const STORAGE_KEY = 'cosmeticState'
+
+const defaultState: CosmeticState = {
+  equipped: {
+    shareEmoji: 'emoji_default',
+  },
+}
+
+export const loadCosmeticState = (): CosmeticState => {
+  const data = localStorage.getItem(STORAGE_KEY)
+  return data
+    ? { ...defaultState, ...(JSON.parse(data) as Partial<CosmeticState>) }
+    : { ...defaultState }
+}
+
+export const saveCosmeticState = (state: CosmeticState): void => {
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(state))
+}
+
+export const equipCosmetic = (
+  category: CosmeticCategory,
+  optionId: string
+): void => {
+  const state = loadCosmeticState()
+  state.equipped[category] = optionId
+  saveCosmeticState(state)
+}
+
+// --- Getters ---
+
+export const getEquippedShareEmoji = (): ShareEmojiSet => {
+  const state = loadCosmeticState()
+  const optionId = state.equipped.shareEmoji
+  return SHARE_EMOJI_SETS[optionId] ?? SHARE_EMOJI_SETS['emoji_default']
+}
+
+export const getShareEmojiSet = (optionId: string): ShareEmojiSet => {
+  return SHARE_EMOJI_SETS[optionId] ?? SHARE_EMOJI_SETS['emoji_default']
+}

--- a/src/lib/share.ts
+++ b/src/lib/share.ts
@@ -2,6 +2,7 @@ import { Temporal } from 'temporal-polyfill'
 import { getGuessStatuses } from './statuses'
 import { CONFIG } from '../constants/config'
 import { DailyHistory, dateToKey, getDailyHistoryStartDate } from './dailyHistory'
+import { getEquippedShareEmoji } from './cosmetics'
 
 export const shareCustomStatus = (
   guesses: string[][],
@@ -97,16 +98,17 @@ export const shareCalendar = (
     const isPreCalendarEpoch =
       startDate !== null && key < startDate
 
+    const emoji = getEquippedShareEmoji()
     if (isFuture || isBeforeEpoch || isPreCalendarEpoch) {
-      row.push('⚪') // inactive (future / before epoch / pre-calendar)
+      row.push('\u26AA') // inactive (future / before epoch / pre-calendar)
     } else {
       const result = dailyHistory[key]
       if (!result) {
-        row.push('⬜') // not played
+        row.push(emoji.absent) // not played
       } else if (result.won) {
-        row.push('🟩') // won
+        row.push(emoji.correct) // won
       } else {
-        row.push('🟪') // lost
+        row.push(emoji.present) // lost
       }
     }
 
@@ -137,6 +139,7 @@ export const generateEmojiGrid = (
   guesses: string[][],
   solution: string
 ) => {
+  const emoji = getEquippedShareEmoji()
   return guesses
     .map((guess, gi) => {
       const status = getGuessStatuses(guess, solution)
@@ -144,11 +147,11 @@ export const generateEmojiGrid = (
         .map((_, i) => {
           switch (status[i]) {
             case 'correct':
-              return '🟩'
+              return emoji.correct
             case 'present':
-              return '🟪'
+              return emoji.present
             default:
-              return '⬜'
+              return emoji.absent
           }
         })
         .join('')


### PR DESCRIPTION
## Summary

- 치장품 데이터 모델 + 장착 상태 localStorage 관리 (`cosmetics.ts`)
- Share 이모지 옵션 3개: Default(🟩🟪⬜), Circle(🟢🟣⚪), Heart(💚💜🤍)
- `share.ts` 하드코딩 이모지 → `getEquippedShareEmoji()` 참조로 변경
- `achievements.ts`에 rewardId 매핑 (play_10→emoji_circle, streak_3→emoji_heart)
- 나머지 4종 치장품(폰트, 글자색, 체인, 종료 문구)은 후속 이슈

Closes #107

## Test plan

- [x] `CI=true npm run build` 통과
- [x] `npm test` 통과
- [x] 기본 이모지로 Share 정상 동작 확인
- [x] localStorage에서 emoji_circle 장착 후 Share → 🟢🟣⚪ 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)