### PR TITLE
fix: Calendar 탭 Share 버튼 수평 배치 (#111)

### DIFF
--- a/src/components/calendar/Calendar.tsx
+++ b/src/components/calendar/Calendar.tsx
@@ -212,14 +212,17 @@ export const Calendar = ({ gameStats, handleShare, weekStartsOnMonday, excludeUr
       </div>
 
       {/* Streak + Share button */}
-      <div className="w-full flex flex-col items-center">
-        <div className="text-lg font-semibold text-gray-900">
-          🔥 {gameStats.currentStreak}
+      <div className="columns-2 w-full">
+        <div>
+          <h5>{t('currentStreak')}</h5>
+          <span className="text-lg font-semibold text-gray-900">
+            🔥 {gameStats.currentStreak}
+          </span>
         </div>
         <button
           type="button"
           disabled={!hasAnyData}
-          className={`mt-3 w-full rounded-md border border-transparent shadow-sm px-4 py-2 text-base font-medium text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:text-sm ${hasAnyData ? 'bg-indigo-600 hover:bg-indigo-700 cursor-pointer' : 'bg-gray-300 cursor-default'}`}
+          className={`mt-2 w-full rounded-md border border-transparent shadow-sm px-4 py-2 text-base font-medium text-white focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 sm:text-sm ${hasAnyData ? 'bg-indigo-600 hover:bg-indigo-700 cursor-pointer' : 'bg-gray-300 cursor-default'}`}
           onClick={() => {
             shareCalendar(year, month, history, gameStats.currentStreak, weekStartsOnMonday, excludeUrl)
             handleShare()


### PR DESCRIPTION
Closes #111

## Summary

- Calendar 탭의 Streak + Share 버튼을 `columns-2`로 수평 배치 (Statistics 탭과 동일 레이아웃)
- 모바일에서 Share 버튼 하단 여백 부족 문제 해결

## Test plan

- [x] `CI=true npm run build` 통과
- [x] 데스크톱/모바일에서 Calendar 탭 레이아웃 확인
- [x] Statistics 탭과 동일한 버튼 배치 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)