### PR TITLE
docs: README 버전 뱃지 동적 전환 + bump-version 스킬 업데이트 (#113)

### DIFF
--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -12,11 +12,11 @@ argument-hint: <version> (e.g. 1.1.0)
 
 1. `package.json` → `"version"` 필드
 2. `src/constants/config.ts` → `PATCH_NOTES_VERSION` 상수
-3. `README.md` → 버전 뱃지 (`![Version](https://img.shields.io/badge/Version-v...-blue)`)
+
+> `README.md` 버전 뱃지는 GitHub Release 기반 동적 뱃지이므로 수동 업데이트 불필요.
 
 ## 절차
 
 1. `npm version $ARGUMENTS --no-git-tag-version` 으로 package.json, package-lock.json 업데이트
 2. `src/constants/config.ts`의 `PATCH_NOTES_VERSION` 값을 `'$ARGUMENTS'`로 변경
-3. `README.md`의 버전 뱃지를 `v$ARGUMENTS`로 변경
 3. 변경된 파일 목록을 사용자에게 보여줌 (커밋은 하지 않음)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -133,7 +133,8 @@ PR을 만들 때 아래 항목을 반드시 설정한다:
 
 - `package.json` → `"version"` 필드
 - `src/constants/config.ts` → `PATCH_NOTES_VERSION` 상수
-- `README.md` → 버전 뱃지
+
+> `README.md` 버전 뱃지는 GitHub Release 기반 동적 뱃지이므로 수동 업데이트 불필요.
 
 `release/{version}` 브랜치를 `main`으로 PR할 때 위 값들이 해당 버전과 반드시 일치해야 한다. `/bump-version` 스킬로 일괄 업데이트 가능.
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -115,6 +115,7 @@ PR을 만들 때 아래 항목을 반드시 설정한다:
   - `🔖 versioning` — release → main PR 전용
   - `🧑‍💻 devops` — 개발 환경/CI/테스트
   - `💥 breaking change` — 호환성 깨지는 변경
+  - `🌐 i18n` — 다국어/번역
   - `browser: chrome`, `browser: safari` — 브라우저 한정
   - `platform: PC`, `platform: mobile` — 플랫폼 한정
 - **Assignee**: `--assignee Ootzk`

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Wor-chain-dle
 
-![Version](https://img.shields.io/badge/Version-v1.4.0-blue)
+[![Release](https://img.shields.io/github/v/release/Ootzk/Wor-chain-dle?label=release&logo=github)](https://github.com/Ootzk/Wor-chain-dle/releases)
 
 **Wordle meets word chain** — guess the word while chaining letters in a snake pattern.
 


### PR DESCRIPTION
Closes #113

## Summary

- README.md 버전 뱃지: 수동 `v1.4.0` → GitHub Release 기반 동적 뱃지
- bump-version 스킬에서 README 업데이트 항목 제거
- CLAUDE.md: Version Management 섹션 업데이트, PR 라벨 목록에 `🌐 i18n` 추가

🤖 Generated with [Claude Code](https://claude.com/claude-code)