### PR TITLE
fix: E2E 테스트 weekStart 설정 제거 반영

### DIFF
--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -123,26 +123,7 @@ test.describe('Calendar', () => {
     await screenshot(gamePage, '02-back-to-current')
   })
 
-  test('week starts on Monday setting', async ({ gamePage }) => {
-    // Open calendar tab — default Sunday start
-    await openCalendarTab(gamePage)
-    const weekdayHeaders = gamePage.locator('.w-10.text-center.text-xs.font-medium')
-    await expect(weekdayHeaders.first()).toHaveText('Su')
-    await screenshot(gamePage, '01-sunday-start')
-    await gamePage.keyboard.press('Escape')
-
-    // Enable weekStartsOnMonday in settings (2nd toggle)
-    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(SETTINGS_ICON).click()
-    await expect(gamePage.locator('text=Start Week on Monday')).toBeVisible()
-    await gamePage.locator('button[role="switch"]').nth(1).click()
-    await gamePage.keyboard.press('Escape')
-
-    // Reopen calendar tab — Monday start
-    await openCalendarTab(gamePage)
-    await expect(weekdayHeaders.first()).toHaveText('Mo')
-    await expect(weekdayHeaders.last()).toHaveText('Su')
-    await screenshot(gamePage, '02-monday-start')
-  })
+  // weekStart setting removed in v1.5.0
 
   test('share button disabled without data, enabled with data', async ({ gamePage }) => {
     await openCalendarTab(gamePage)

--- a/e2e/share-exclude-url.spec.ts
+++ b/e2e/share-exclude-url.spec.ts
@@ -42,8 +42,8 @@ test.describe('Share — Exclude URL setting', () => {
     const settingsIndex = 1
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(settingsIndex).click()
     await expect(gamePage.locator('text=Settings')).toBeVisible()
-    // Exclude URL is the 3rd toggle (0:uppercase, 1:weekStart, 2:excludeUrl)
-    await gamePage.locator('button[role="switch"]').nth(2).click()
+    // Exclude URL is the 2nd toggle (0:uppercase, 1:excludeUrl)
+    await gamePage.locator('button[role="switch"]').nth(1).click()
     await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
     await expect(gamePage.locator('text=Settings')).not.toBeVisible()
   }


### PR DESCRIPTION
## Summary

- `calendar.spec.ts`: week starts on Monday 테스트 제거 (v1.5.0에서 설정 삭제됨)
- `share-exclude-url.spec.ts`: Exclude URL 토글 인덱스 수정 (weekStart 제거로 nth(2) → nth(1))

🤖 Generated with [Claude Code](https://claude.com/claude-code)