### PR TITLE
fix: E2E 테스트 로케이터 수정

### DIFF
--- a/e2e/achievements-cosmetics.spec.ts
+++ b/e2e/achievements-cosmetics.spec.ts
@@ -19,8 +19,8 @@ test.describe('Achievements & Cosmetics', () => {
     await expect(gamePage.locator('text=Play 10 games')).toBeVisible()
     await screenshot(gamePage, '01-achievements-tab')
 
-    // Progress bar should be visible
-    await expect(gamePage.locator('div.bg-indigo-500').first()).toBeVisible()
+    // Progress bar container should be visible
+    await expect(gamePage.locator('div.bg-gray-200.rounded-full').first()).toBeVisible()
     await screenshot(gamePage, '02-achievements-progress')
   })
 
@@ -134,16 +134,17 @@ test.describe('Achievements & Cosmetics', () => {
     // Open settings
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
 
-    // Click Share Emoji picker button
-    await gamePage.locator('text=Share Emoji').locator('..').locator('button').click()
+    // Click Share Emoji picker button (first cosmetic picker)
+    await gamePage.locator('button:has-text("Square")').click()
 
-    // Popup should show options
-    await expect(gamePage.locator('text=Square')).toBeVisible()
-    await expect(gamePage.locator('text=Circle')).toBeVisible()
+    // Popup should show options (z-[60] is the cosmetic picker overlay)
+    const popup = gamePage.locator('.z-\\[60\\]')
+    await expect(popup).toBeVisible()
+    await expect(popup.locator('text=Circle')).toBeVisible()
     await screenshot(gamePage, '01-emoji-picker-popup')
 
     // Select Circle
-    await gamePage.locator('div', { hasText: 'Circle' }).last().click()
+    await popup.locator('text=Circle').click()
 
     // Preview should update
     const sharePreview = gamePage.locator('pre')
@@ -156,7 +157,7 @@ test.describe('Achievements & Cosmetics', () => {
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
 
     // Click Share Emoji picker
-    await gamePage.locator('text=Share Emoji').locator('..').locator('button').click()
+    await gamePage.locator('button:has-text("Square")').click()
 
     // Circle and Heart should show lock (not unlocked)
     await expect(gamePage.locator('text=\uD83D\uDD12').first()).toBeVisible()

--- a/e2e/modals.spec.ts
+++ b/e2e/modals.spec.ts
@@ -135,7 +135,7 @@ test.describe('Modals', () => {
     await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
 
     // Grid and keyboard should have uppercase class
-    await expect(gamePage.locator('div.uppercase')).toBeVisible()
+    await expect(gamePage.locator('div.uppercase').first()).toBeVisible()
     await screenshot(gamePage, '03-uppercase-applied-to-page')
 
     // Reopen settings and toggle off
@@ -145,7 +145,7 @@ test.describe('Modals', () => {
     await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
 
     // Uppercase class should be gone
-    await expect(gamePage.locator('div.uppercase')).not.toBeVisible()
+    await expect(gamePage.locator('div.uppercase').first()).not.toBeVisible()
     await screenshot(gamePage, '05-uppercase-removed-from-page')
   })
 
@@ -154,44 +154,44 @@ test.describe('Modals', () => {
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
     await gamePage.locator('button[role="switch"]').first().click()
     await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
-    await expect(gamePage.locator('div.uppercase')).toBeVisible()
+    await expect(gamePage.locator('div.uppercase').first()).toBeVisible()
     await screenshot(gamePage, '01-daily-uppercase-on')
 
     // Daily → Practice
     await gamePage.locator('a', { hasText: 'Practice' }).click()
     await waitForGameReady(gamePage)
-    await expect(gamePage.locator('div.uppercase')).toBeVisible()
+    await expect(gamePage.locator('div.uppercase').first()).toBeVisible()
     await screenshot(gamePage, '02-practice-uppercase-persisted')
 
     // Practice → Daily
     await gamePage.locator('a', { hasText: 'Daily' }).click()
     await waitForGameReady(gamePage)
-    await expect(gamePage.locator('div.uppercase')).toBeVisible()
+    await expect(gamePage.locator('div.uppercase').first()).toBeVisible()
     await screenshot(gamePage, '03-daily-uppercase-still-on')
 
     // Daily → Create
     await gamePage.locator('a', { hasText: 'Create' }).click()
     await gamePage.locator('button', { hasText: 'Enter' }).waitFor({ state: 'visible' })
-    await expect(gamePage.locator('div.uppercase')).toBeVisible()
+    await expect(gamePage.locator('div.uppercase').first()).toBeVisible()
     await screenshot(gamePage, '04-create-uppercase-persisted')
 
     // Toggle off on Create page (settings = 2nd icon: info, settings)
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(1).click()
     await gamePage.locator('button[role="switch"]').first().click()
     await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
-    await expect(gamePage.locator('div.uppercase')).not.toBeVisible()
+    await expect(gamePage.locator('div.uppercase').first()).not.toBeVisible()
     await screenshot(gamePage, '05-create-uppercase-off')
 
     // Create → Daily
     await gamePage.locator('a', { hasText: 'Daily' }).click()
     await waitForGameReady(gamePage)
-    await expect(gamePage.locator('div.uppercase')).not.toBeVisible()
+    await expect(gamePage.locator('div.uppercase').first()).not.toBeVisible()
     await screenshot(gamePage, '06-daily-uppercase-off-persisted')
 
     // Daily → Custom
     await gamePage.goto(customPuzzlePath('crane', 'Alice'))
     await waitForGameReady(gamePage)
-    await expect(gamePage.locator('div.uppercase')).not.toBeVisible()
+    await expect(gamePage.locator('div.uppercase').first()).not.toBeVisible()
     await screenshot(gamePage, '07-custom-uppercase-off-persisted')
   })
 
@@ -236,20 +236,20 @@ test.describe('Modals', () => {
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
     await expect(gamePage.locator('text=Settings')).toBeVisible()
 
-    // Language picker button should be visible with English flag
-    await expect(gamePage.locator('text=English')).toBeVisible()
+    // Language picker button should be visible with English
+    await expect(gamePage.locator('button:has-text("English")')).toBeVisible()
     await screenshot(gamePage, '01-settings-language-picker')
 
     // Click to open language popup
-    await gamePage.locator('text=English').locator('..').locator('button').click()
+    await gamePage.locator('button:has-text("English")').click()
 
     // Popup should show all languages
     await expect(gamePage.locator('text=한국어')).toBeVisible()
     await expect(gamePage.locator('text=日本語')).toBeVisible()
     await screenshot(gamePage, '02-settings-language-popup')
 
-    // Close popup by clicking outside
-    await gamePage.locator('.fixed.inset-0').click({ position: { x: 10, y: 10 } })
+    // Close popup
+    await gamePage.keyboard.press('Escape')
   })
 
   test('modal closes on Escape key', async ({ gamePage }) => {

--- a/e2e/share-exclude-url.spec.ts
+++ b/e2e/share-exclude-url.spec.ts
@@ -86,7 +86,8 @@ test.describe('Share — Exclude URL setting', () => {
     // Enable Exclude URL on daily page
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(SETTINGS_ICON_DAILY).click()
     await expect(gamePage.locator('text=Settings')).toBeVisible()
-    const excludeToggle = gamePage.locator('button[role="switch"]').nth(2)
+    // Exclude URL is the 2nd toggle (0:uppercase, 1:excludeUrl)
+    const excludeToggle = gamePage.locator('button[role="switch"]').nth(1)
     await expect(excludeToggle).toHaveAttribute('aria-checked', 'false')
     await excludeToggle.click()
     await expect(excludeToggle).toHaveAttribute('aria-checked', 'true')
@@ -100,7 +101,7 @@ test.describe('Share — Exclude URL setting', () => {
     // Reopen settings — toggle should still be on
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(SETTINGS_ICON_DAILY).click()
     await expect(gamePage.locator('text=Settings')).toBeVisible()
-    const toggleAfter = gamePage.locator('button[role="switch"]').nth(2)
+    const toggleAfter = gamePage.locator('button[role="switch"]').nth(1)
     await expect(toggleAfter).toHaveAttribute('aria-checked', 'true')
     await screenshot(gamePage, '02-exclude-url-persisted-after-reload')
   })


### PR DESCRIPTION
## Summary

v1.5.0 UI 변경으로 인한 E2E 로케이터 수정:

- `div.uppercase` → `.first()` (Settings 샘플뷰에 uppercase 클래스 추가됨)
- cosmetic picker: `.fixed.inset-0` → `.z-\[60\]` (팝업 구분)
- language selector: 부모 체인 → `button:has-text("English")`, Escape로 닫기
- share-exclude-url: Daily 모드 토글 인덱스 `nth(2)` → `nth(1)`

## Test plan

- [x] 로컬 Chromium E2E 전체 통과 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)