### PR TITLE
feat: Information 모달에 패치노트 탭 추가

### DIFF
--- a/e2e/modals.spec.ts
+++ b/e2e/modals.spec.ts
@@ -20,10 +20,15 @@ test.describe('Modals', () => {
     await expect(gamePage.locator('text=Chain Rule')).toBeVisible()
     await screenshot(gamePage, '02-daily-tab-how-to-play')
 
-    // Tab 3: About this game
+    // Tab 3: Patch Notes
+    await gamePage.locator('button', { hasText: 'Patch Notes' }).click()
+    await expect(gamePage.getByText('Achievements', { exact: true })).toBeVisible()
+    await screenshot(gamePage, '03-daily-tab-patch-notes')
+
+    // Tab 4: About this game
     await gamePage.locator('button', { hasText: 'About this game' }).click()
     await expect(gamePage.locator('text=open source word guessing game')).toBeVisible()
-    await screenshot(gamePage, '03-daily-tab-about')
+    await screenshot(gamePage, '04-daily-tab-about')
 
     // Close
     await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()

--- a/e2e/modals.spec.ts
+++ b/e2e/modals.spec.ts
@@ -23,6 +23,8 @@ test.describe('Modals', () => {
     // Tab 3: Patch Notes
     await gamePage.locator('button', { hasText: 'Patch Notes' }).click()
     await expect(gamePage.getByText('Achievements', { exact: true })).toBeVisible()
+    await gamePage.locator('button', { hasText: 'v1.4.0' }).click()
+    await expect(gamePage.getByText('Local Timezone Reset')).toBeVisible()
     await screenshot(gamePage, '03-daily-tab-patch-notes')
 
     // Tab 4: About this game

--- a/src/components/modals/InfoModal.tsx
+++ b/src/components/modals/InfoModal.tsx
@@ -6,6 +6,7 @@ import { InformationCircleIcon } from '@heroicons/react/outline'
 import { CONFIG } from '../../constants/config'
 import { Trans, useTranslation } from 'react-i18next'
 import 'i18next'
+import { PatchNotesContent } from './PatchNotesContent'
 
 type GameMode = 'daily' | 'practice' | 'custom' | 'create'
 
@@ -220,6 +221,7 @@ export const InfoModal = ({ isOpen, handleClose, mode, questioner }: Props) => {
   const tabs = [
     { id: 'mode', label: t(MODE_TITLE_KEY[mode]) },
     { id: 'howToPlay', label: t('howToPlay') },
+    { id: 'patchNotes', label: t('patchNotes') },
     { id: 'about', label: t('about') },
   ]
 
@@ -230,11 +232,11 @@ export const InfoModal = ({ isOpen, handleClose, mode, questioner }: Props) => {
       isOpen={isOpen}
       handleClose={handleClose}
     >
-      <div className="flex border-b border-gray-200 mb-4">
+      <div className="flex overflow-x-auto border-b border-gray-200 mb-4">
         {tabs.map((tab) => (
           <button
             key={tab.id}
-            className={`px-4 py-2 text-sm font-medium ${
+            className={`flex-shrink-0 px-3 sm:px-4 py-2 text-sm font-medium whitespace-nowrap ${
               activeTab === tab.id
                 ? 'border-b-2 border-indigo-600 text-indigo-600 font-bold'
                 : 'text-gray-400 hover:text-gray-600'
@@ -251,6 +253,8 @@ export const InfoModal = ({ isOpen, handleClose, mode, questioner }: Props) => {
       )}
 
       {activeTab === 'howToPlay' && <HowToPlayContent />}
+
+      {activeTab === 'patchNotes' && <PatchNotesContent />}
 
       {activeTab === 'about' && <AboutContent />}
     </BaseModal>

--- a/src/components/modals/InfoModal.tsx
+++ b/src/components/modals/InfoModal.tsx
@@ -254,7 +254,7 @@ export const InfoModal = ({ isOpen, handleClose, mode, questioner }: Props) => {
 
       {activeTab === 'howToPlay' && <HowToPlayContent />}
 
-      {activeTab === 'patchNotes' && <PatchNotesContent />}
+      {activeTab === 'patchNotes' && <PatchNotesContent variant="history" />}
 
       {activeTab === 'about' && <AboutContent />}
     </BaseModal>

--- a/src/components/modals/PatchNotesContent.tsx
+++ b/src/components/modals/PatchNotesContent.tsx
@@ -1,3 +1,5 @@
+import { Disclosure } from '@headlessui/react'
+import { ChevronDownIcon } from '@heroicons/react/outline'
 import { PATCH_NOTES_VERSION } from '../../constants/config'
 import { useTranslation } from 'react-i18next'
 
@@ -31,8 +33,163 @@ const features: Feature[] = [
   },
 ]
 
-export const PatchNotesContent = () => {
+const patchNoteVersions: { version: string; features: Feature[] }[] = [
+  {
+    version: PATCH_NOTES_VERSION,
+    features,
+  },
+  {
+    version: '1.4.0',
+    features: [
+      {
+        icon: '🕛',
+        titleKey: 'patchNote_localTimezone_title',
+        descKey: 'patchNote_localTimezone_desc',
+      },
+      {
+        icon: '🧭',
+        titleKey: 'patchNote_uiRefactor_title',
+        descKey: 'patchNote_uiRefactor_desc',
+      },
+      {
+        icon: '💖',
+        titleKey: 'patchNote_sponsors_title',
+        descKey: 'patchNote_sponsors_desc',
+      },
+    ],
+  },
+  {
+    version: '1.3.0',
+    features: [
+      {
+        icon: '📅',
+        titleKey: 'patchNote_calendar_title',
+        descKey: 'patchNote_calendar_desc',
+      },
+    ],
+  },
+  {
+    version: '1.2.0',
+    features: [
+      {
+        icon: '🧩',
+        titleKey: 'patchNote_customPuzzle_title',
+        descKey: 'patchNote_customPuzzle_desc',
+      },
+      {
+        icon: '💝',
+        titleKey: 'patchNote_donations_title',
+        descKey: 'patchNote_donations_desc',
+        sub: [
+          {
+            icon: '💛',
+            titleKey: 'patchNote_kakaopay_title',
+            descKey: 'patchNote_kakaopay_desc',
+          },
+          {
+            icon: '💙',
+            titleKey: 'patchNote_tosspay_title',
+            descKey: 'patchNote_tosspay_desc',
+          },
+        ],
+      },
+      {
+        icon: 'ℹ️',
+        titleKey: 'patchNote_infoModal_title',
+        descKey: 'patchNote_infoModal_desc',
+      },
+      {
+        icon: '✨',
+        titleKey: 'patchNote_ui_title',
+        descKey: 'patchNote_ui_desc',
+        sub: [
+          {
+            icon: '🏷️',
+            titleKey: 'patchNote_subtitle_title',
+            descKey: 'patchNote_subtitle_desc',
+          },
+          {
+            icon: '🏳️',
+            titleKey: 'patchNote_flags_title',
+            descKey: 'patchNote_flags_desc',
+          },
+        ],
+      },
+    ],
+  },
+]
+
+const PatchNoteFeatureCard = ({ feature }: { feature: Feature }) => {
   const { t } = useTranslation()
+  const { icon, titleKey, descKey, sub } = feature
+
+  return (
+    <div key={titleKey} className="rounded-lg border border-gray-200 p-3">
+      <div className="flex gap-3">
+        <span className="text-xl leading-none">{icon}</span>
+        <div>
+          <p className="text-sm font-semibold text-gray-800">{t(titleKey)}</p>
+          <p className="text-xs text-gray-500 mt-0.5 whitespace-pre-line">
+            {t(descKey)}
+          </p>
+        </div>
+      </div>
+      {sub && (
+        <div className="ml-8 mt-2 space-y-2">
+          {sub.map((s) => (
+            <div key={s.titleKey} className="flex gap-2">
+              {s.icon && <span className="text-sm leading-none">{s.icon}</span>}
+              <div>
+                <p className="text-xs font-semibold text-gray-700">
+                  {t(s.titleKey)}
+                </p>
+                <p className="text-xs text-gray-400 mt-0.5">{t(s.descKey)}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+type Props = {
+  variant?: 'current' | 'history'
+}
+
+export const PatchNotesContent = ({ variant = 'current' }: Props) => {
+  if (variant === 'history') {
+    return (
+      <div className="space-y-3 text-left">
+        {patchNoteVersions.map(({ version, features }, index) => (
+          <Disclosure key={version} defaultOpen={index === 0}>
+            {({ open }) => (
+              <div className="rounded-lg border border-gray-200 overflow-hidden">
+                <Disclosure.Button className="flex w-full items-center justify-between gap-3 bg-gray-50 px-3 py-2 text-left">
+                  <span className="rounded-full bg-indigo-100 px-3 py-1 text-xs font-semibold text-indigo-700">
+                    v{version}
+                  </span>
+                  <ChevronDownIcon
+                    className={`h-4 w-4 text-gray-500 transition-transform ${
+                      open ? 'rotate-180' : ''
+                    }`}
+                  />
+                </Disclosure.Button>
+                <Disclosure.Panel className="space-y-3 p-3">
+                  {features.map((feature) => (
+                    <PatchNoteFeatureCard
+                      key={`${version}-${feature.titleKey}`}
+                      feature={feature}
+                    />
+                  ))}
+                </Disclosure.Panel>
+              </div>
+            )}
+          </Disclosure>
+        ))}
+      </div>
+    )
+  }
 
   return (
     <>
@@ -41,39 +198,8 @@ export const PatchNotesContent = () => {
       </div>
 
       <div className="space-y-3 text-left">
-        {features.map(({ icon, titleKey, descKey, sub }) => (
-          <div key={titleKey} className="rounded-lg border border-gray-200 p-3">
-            <div className="flex gap-3">
-              <span className="text-xl leading-none">{icon}</span>
-              <div>
-                <p className="text-sm font-semibold text-gray-800">
-                  {t(titleKey)}
-                </p>
-                <p className="text-xs text-gray-500 mt-0.5 whitespace-pre-line">
-                  {t(descKey)}
-                </p>
-              </div>
-            </div>
-            {sub && (
-              <div className="ml-8 mt-2 space-y-2">
-                {sub.map((s) => (
-                  <div key={s.titleKey} className="flex gap-2">
-                    {s.icon && (
-                      <span className="text-sm leading-none">{s.icon}</span>
-                    )}
-                    <div>
-                      <p className="text-xs font-semibold text-gray-700">
-                        {t(s.titleKey)}
-                      </p>
-                      <p className="text-xs text-gray-400 mt-0.5">
-                        {t(s.descKey)}
-                      </p>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
+        {features.map((feature) => (
+          <PatchNoteFeatureCard key={feature.titleKey} feature={feature} />
         ))}
       </div>
     </>

--- a/src/components/modals/PatchNotesContent.tsx
+++ b/src/components/modals/PatchNotesContent.tsx
@@ -1,0 +1,81 @@
+import { PATCH_NOTES_VERSION } from '../../constants/config'
+import { useTranslation } from 'react-i18next'
+
+type Feature = {
+  icon: string
+  titleKey: string
+  descKey: string
+  sub?: { icon: string; titleKey: string; descKey: string }[]
+}
+
+const features: Feature[] = [
+  {
+    icon: '🏆',
+    titleKey: 'patchNote_achievements_title',
+    descKey: 'patchNote_achievements_desc',
+  },
+  {
+    icon: '🎨',
+    titleKey: 'patchNote_cosmetics_title',
+    descKey: 'patchNote_cosmetics_desc',
+  },
+  {
+    icon: '🇩🇪',
+    titleKey: 'patchNote_german_title',
+    descKey: 'patchNote_german_desc',
+  },
+  {
+    icon: '🔧',
+    titleKey: 'patchNote_uiFixes_title',
+    descKey: 'patchNote_uiFixes_desc',
+  },
+]
+
+export const PatchNotesContent = () => {
+  const { t } = useTranslation()
+
+  return (
+    <>
+      <div className="inline-block rounded-full bg-indigo-100 px-3 py-1 text-xs font-semibold text-indigo-700 mb-4">
+        v{PATCH_NOTES_VERSION}
+      </div>
+
+      <div className="space-y-3 text-left">
+        {features.map(({ icon, titleKey, descKey, sub }) => (
+          <div key={titleKey} className="rounded-lg border border-gray-200 p-3">
+            <div className="flex gap-3">
+              <span className="text-xl leading-none">{icon}</span>
+              <div>
+                <p className="text-sm font-semibold text-gray-800">
+                  {t(titleKey)}
+                </p>
+                <p className="text-xs text-gray-500 mt-0.5 whitespace-pre-line">
+                  {t(descKey)}
+                </p>
+              </div>
+            </div>
+            {sub && (
+              <div className="ml-8 mt-2 space-y-2">
+                {sub.map((s) => (
+                  <div key={s.titleKey} className="flex gap-2">
+                    {s.icon && (
+                      <span className="text-sm leading-none">{s.icon}</span>
+                    )}
+                    <div>
+                      <p className="text-xs font-semibold text-gray-700">
+                        {t(s.titleKey)}
+                      </p>
+                      <p className="text-xs text-gray-400 mt-0.5">
+                        {t(s.descKey)}
+                      </p>
+                    </div>
+                  </div>
+                ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </>
+  )
+}

--- a/src/components/modals/PatchNotesContent.tsx
+++ b/src/components/modals/PatchNotesContent.tsx
@@ -10,33 +10,36 @@ type Feature = {
   sub?: { icon: string; titleKey: string; descKey: string }[]
 }
 
-const features: Feature[] = [
-  {
-    icon: '🏆',
-    titleKey: 'patchNote_achievements_title',
-    descKey: 'patchNote_achievements_desc',
-  },
-  {
-    icon: '🎨',
-    titleKey: 'patchNote_cosmetics_title',
-    descKey: 'patchNote_cosmetics_desc',
-  },
-  {
-    icon: '🇩🇪',
-    titleKey: 'patchNote_german_title',
-    descKey: 'patchNote_german_desc',
-  },
-  {
-    icon: '🔧',
-    titleKey: 'patchNote_uiFixes_title',
-    descKey: 'patchNote_uiFixes_desc',
-  },
-]
+type PatchNoteVersion = {
+  version: string
+  features: Feature[]
+}
 
-const patchNoteVersions: { version: string; features: Feature[] }[] = [
+const patchNoteVersions: PatchNoteVersion[] = [
   {
-    version: PATCH_NOTES_VERSION,
-    features,
+    version: '1.5.0',
+    features: [
+      {
+        icon: '🏆',
+        titleKey: 'patchNote_achievements_title',
+        descKey: 'patchNote_achievements_desc',
+      },
+      {
+        icon: '🎨',
+        titleKey: 'patchNote_cosmetics_title',
+        descKey: 'patchNote_cosmetics_desc',
+      },
+      {
+        icon: '🇩🇪',
+        titleKey: 'patchNote_german_title',
+        descKey: 'patchNote_german_desc',
+      },
+      {
+        icon: '🔧',
+        titleKey: 'patchNote_uiFixes_title',
+        descKey: 'patchNote_uiFixes_desc',
+      },
+    ],
   },
   {
     version: '1.4.0',
@@ -119,6 +122,10 @@ const patchNoteVersions: { version: string; features: Feature[] }[] = [
   },
 ]
 
+const currentPatchNotes =
+  patchNoteVersions.find(({ version }) => version === PATCH_NOTES_VERSION) ??
+  patchNoteVersions[0]
+
 const PatchNoteFeatureCard = ({ feature }: { feature: Feature }) => {
   const { t } = useTranslation()
   const { icon, titleKey, descKey, sub } = feature
@@ -194,11 +201,11 @@ export const PatchNotesContent = ({ variant = 'current' }: Props) => {
   return (
     <>
       <div className="inline-block rounded-full bg-indigo-100 px-3 py-1 text-xs font-semibold text-indigo-700 mb-4">
-        v{PATCH_NOTES_VERSION}
+        v{currentPatchNotes.version}
       </div>
 
       <div className="space-y-3 text-left">
-        {features.map((feature) => (
+        {currentPatchNotes.features.map((feature) => (
           <PatchNoteFeatureCard key={feature.titleKey} feature={feature} />
         ))}
       </div>

--- a/src/components/modals/PatchNotesModal.tsx
+++ b/src/components/modals/PatchNotesModal.tsx
@@ -1,45 +1,16 @@
 import { BaseModal } from './BaseModal'
 import { SparklesIcon } from '@heroicons/react/outline'
-import { PATCH_NOTES_VERSION } from '../../constants/config'
 import { useTranslation } from 'react-i18next'
+import { PatchNotesContent } from './PatchNotesContent'
 
 type Props = {
   isOpen: boolean
   handleClose: () => void
 }
 
-type Feature = {
-  icon: string
-  titleKey: string
-  descKey: string
-  sub?: { icon: string; titleKey: string; descKey: string }[]
-}
-
-const features: Feature[] = [
-  {
-    icon: '🏆',
-    titleKey: 'patchNote_achievements_title',
-    descKey: 'patchNote_achievements_desc',
-  },
-  {
-    icon: '🎨',
-    titleKey: 'patchNote_cosmetics_title',
-    descKey: 'patchNote_cosmetics_desc',
-  },
-  {
-    icon: '🇩🇪',
-    titleKey: 'patchNote_german_title',
-    descKey: 'patchNote_german_desc',
-  },
-  {
-    icon: '🔧',
-    titleKey: 'patchNote_uiFixes_title',
-    descKey: 'patchNote_uiFixes_desc',
-  },
-]
-
 export const PatchNotesModal = ({ isOpen, handleClose }: Props) => {
   const { t } = useTranslation()
+
   return (
     <BaseModal
       title={t('patchNotesTitle')}
@@ -47,45 +18,7 @@ export const PatchNotesModal = ({ isOpen, handleClose }: Props) => {
       isOpen={isOpen}
       handleClose={handleClose}
     >
-      <div className="inline-block rounded-full bg-indigo-100 px-3 py-1 text-xs font-semibold text-indigo-700 mb-4">
-        v{PATCH_NOTES_VERSION}
-      </div>
-
-      <div className="space-y-3 text-left">
-        {features.map(({ icon, titleKey, descKey, sub }) => (
-          <div
-            key={titleKey}
-            className="rounded-lg border border-gray-200 p-3"
-          >
-            <div className="flex gap-3">
-              <span className="text-xl leading-none">{icon}</span>
-              <div>
-                <p className="text-sm font-semibold text-gray-800">
-                  {t(titleKey)}
-                </p>
-                <p className="text-xs text-gray-500 mt-0.5 whitespace-pre-line">{t(descKey)}</p>
-              </div>
-            </div>
-            {sub && (
-              <div className="ml-8 mt-2 space-y-2">
-                {sub.map((s) => (
-                  <div key={s.titleKey} className="flex gap-2">
-                    {s.icon && <span className="text-sm leading-none">{s.icon}</span>}
-                    <div>
-                      <p className="text-xs font-semibold text-gray-700">
-                        {t(s.titleKey)}
-                      </p>
-                      <p className="text-xs text-gray-400 mt-0.5">
-                        {t(s.descKey)}
-                      </p>
-                    </div>
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-        ))}
-      </div>
+      <PatchNotesContent />
     </BaseModal>
   )
 }

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -114,6 +114,8 @@
   "shareMonth": "Monat teilen",
   "calendarCopied": "Kalender in die Zwischenablage kopiert",
   "weekdays": ["So", "Mo", "Di", "Mi", "Do", "Fr", "Sa"],
+  "patchNote_calendar_title": "Monatskalender",
+  "patchNote_calendar_desc": "Verfolge tägliche Ergebnisse im Monatskalender, wechsle zwischen Monaten und teile deinen Monatsverlauf als Emoji-Raster.",
   "patchNote_localTimezone_title": "Lokale Zeitzone",
   "patchNote_localTimezone_desc": "Das tägliche Wort wechselt jetzt um Mitternacht deiner lokalen Zeit statt UTC.\nEgal wo du bist, ein neues Rätsel beginnt um Mitternacht!",
   "patchNote_uiRefactor_title": "UI-Überarbeitung",

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -1,6 +1,7 @@
 {
   "about": "Über dieses Spiel",
   "information": "Information",
+  "patchNotes": "Updates",
   "gameName": "Wörter-Ratespiel - {{language}}",
   "enterKey": "Eingabe",
   "deleteKey": "Löschen",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -174,6 +174,8 @@
     "shareMonth": "Share Month",
     "calendarCopied": "Calendar copied to clipboard",
     "weekdays": ["Su", "Mo", "Tu", "We", "Th", "Fr", "Sa"],
+    "patchNote_calendar_title": "Monthly Calendar",
+    "patchNote_calendar_desc": "Track Daily results on a monthly calendar, navigate between months, and share your monthly record as an emoji grid.",
     "patchNote_localTimezone_title": "Local Timezone Reset",
     "patchNote_localTimezone_desc": "Daily word now resets at your device's local midnight instead of UTC.\nNo matter where you are, a new puzzle starts at midnight!",
     "patchNote_uiRefactor_title": "UI Refactoring",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -1,6 +1,7 @@
 {
     "about": "About this game",
     "information": "Information",
+    "patchNotes": "Patch Notes",
     "gameName": "Word Guessing Game - {{language}}",
     "enterKey": "Enter",
     "deleteKey": "Delete",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -1,6 +1,7 @@
 {
   "about": "Acerca de este juego",
   "information": "Información",
+  "patchNotes": "Novedades",
   "gameName": "No Word-Guessing-Game - {{language}}",
   "enterKey": "Enviar",
   "deleteKey": "Eliminar",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -173,6 +173,8 @@
   "shareMonth": "Compartir mes",
   "calendarCopied": "Calendario copiado al portapapeles",
   "weekdays": ["Do", "Lu", "Ma", "Mi", "Ju", "Vi", "Sá"],
+  "patchNote_calendar_title": "Calendario mensual",
+  "patchNote_calendar_desc": "Consulta tus resultados diarios en un calendario mensual, cambia de mes y comparte tu registro mensual como una cuadrícula de emojis.",
   "patchNote_localTimezone_title": "Reinicio por zona horaria local",
   "patchNote_localTimezone_desc": "La palabra diaria ahora se renueva a medianoche local en lugar de UTC.\n¡Donde sea que estés, un nuevo rompecabezas comienza a medianoche!",
   "patchNote_uiRefactor_title": "Rediseño de UI",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -132,6 +132,8 @@
     "shareMonth": "月間記録を共有",
     "calendarCopied": "カレンダーがクリップボードにコピーされました",
     "weekdays": ["日", "月", "火", "水", "木", "金", "土"],
+    "patchNote_calendar_title": "月間カレンダー",
+    "patchNote_calendar_desc": "デイリー結果を月間カレンダーで確認し、月を移動して絵文字グリッドで月間記録を共有できます。",
     "patchNote_localTimezone_title": "ローカルタイムゾーンリセット",
     "patchNote_localTimezone_desc": "単語の更新がUTCではなくデバイスのローカル深夜基準に変更されました。\nどこにいても深夜に新しい問題が始まります！",
     "patchNote_uiRefactor_title": "UIリファクタリング",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -1,6 +1,7 @@
 {
     "about": "このゲームについて",
     "information": "情報",
+    "patchNotes": "アップデート",
     "gameName": "単語当てゲーム - {{language}}",
     "enterKey": "入力",
     "deleteKey": "削除",

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -132,6 +132,8 @@
     "shareMonth": "월간 기록 공유",
     "calendarCopied": "달력이 클립보드에 복사되었습니다",
     "weekdays": ["일", "월", "화", "수", "목", "금", "토"],
+    "patchNote_calendar_title": "월별 달력",
+    "patchNote_calendar_desc": "데일리 기록을 월별 달력으로 확인하고, 월 이동과 이모지 월간 기록 공유를 사용할 수 있습니다.",
     "patchNote_localTimezone_title": "로컬 타임존 자정 리셋",
     "patchNote_localTimezone_desc": "단어 갱신이 UTC가 아닌 디바이스 로컬 자정 기준으로 변경되었습니다.\n이제 어디서든 자정에 새 문제가 시작됩니다!",
     "patchNote_uiRefactor_title": "UI 리팩토링",

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -1,6 +1,7 @@
 {
     "about": "게임 소개",
     "information": "정보",
+    "patchNotes": "업데이트",
     "gameName": "단어 맞히기 게임 - {{language}}",
     "enterKey": "입력",
     "deleteKey": "삭제",

--- a/src/locales/sw/translation.json
+++ b/src/locales/sw/translation.json
@@ -1,6 +1,7 @@
 {
   "about": "Habari ya mchezo huu",
   "information": "Taarifa",
+  "patchNotes": "Mambo Mapya",
   "gameName": "Si Word-Guessing-Game - {{language}}",
   "enterKey": "Ingiza",
   "deleteKey": "Futa",

--- a/src/locales/sw/translation.json
+++ b/src/locales/sw/translation.json
@@ -173,6 +173,8 @@
   "shareMonth": "Shiriki mwezi",
   "calendarCopied": "Kalenda imenakiliwa kwenye ubao",
   "weekdays": ["Jpi", "Jtt", "Jnn", "Jtn", "Alh", "Iju", "Jmo"],
+  "patchNote_calendar_title": "Kalenda ya mwezi",
+  "patchNote_calendar_desc": "Fuatilia matokeo ya kila siku kwenye kalenda ya mwezi, badilisha miezi, na shiriki rekodi ya mwezi kwa gridi ya emoji.",
   "patchNote_localTimezone_title": "Upya kwa Saa ya Eneo",
   "patchNote_localTimezone_desc": "Neno la kila siku sasa linabadilika usiku wa manane wa eneo lako badala ya UTC.\nPopote ulipo, fumbo jipya linaanza usiku wa manane!",
   "patchNote_uiRefactor_title": "Uboreshaji wa UI",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -1,6 +1,7 @@
 {
   "about": "關於本遊戲",
   "information": "信息",
+  "patchNotes": "更新",
   "gameName": "No Word-Guessing-Game - {{language}}",
   "enterKey": "輸入",
   "deleteKey": "刪除",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -173,6 +173,8 @@
   "shareMonth": "分享月度记录",
   "calendarCopied": "日历已复制到剪贴板",
   "weekdays": ["日", "一", "二", "三", "四", "五", "六"],
+  "patchNote_calendar_title": "月曆",
+  "patchNote_calendar_desc": "在月曆中查看每日結果、切換月份，並以表情符號格分享月度紀錄。",
   "patchNote_localTimezone_title": "本地时区重置",
   "patchNote_localTimezone_desc": "每日单词现在按设备本地午夜更新，而非UTC。\n无论你在哪里，午夜都会开始新的谜题！",
   "patchNote_uiRefactor_title": "UI重构",


### PR DESCRIPTION
Closes #130

## Summary
- Add a Patch Notes tab to the Information modal.
- Reuse the existing What is New content through a shared PatchNotesContent component.
- Show version history in the Information tab as an accordion while keeping the first-visit popup focused on the current version.
- Add patch note tab labels and v1.3.0 calendar note text across locales.

## Test plan
- PUBLIC_URL=/ npm run build
- npx prettier --check src/components/modals/InfoModal.tsx src/components/modals/PatchNotesModal.tsx src/components/modals/PatchNotesContent.tsx
- npx playwright test e2e/modals.spec.ts --project=chromium --grep "info modal" --workers=1
- npx playwright test e2e/modals.spec.ts --project=chromium --grep "PatchNotes" --workers=1