### PR TITLE
chore: make agent skills canonical

### DIFF
--- a/.agents/skills/bump-version/SKILL.md
+++ b/.agents/skills/bump-version/SKILL.md
@@ -1,4 +1,10 @@
-# Version Bump Workflow
+---
+name: bump-version
+description: 프로젝트 내 모든 버전 정보를 일괄 업데이트합니다.
+argument-hint: <version> (e.g. 1.6.0)
+---
+
+# Version Bump
 
 Use this workflow to update project version metadata before a release PR.
 

--- a/.agents/skills/cleanup/SKILL.md
+++ b/.agents/skills/cleanup/SKILL.md
@@ -1,4 +1,9 @@
-# Post-Merge Cleanup Workflow
+---
+name: cleanup
+description: feature 브랜치 머지 후 로컬 정리 (release 전환, pull, 브랜치 삭제, prune)
+---
+
+# Post-Merge Cleanup
 
 Use this workflow after a feature PR has been merged into a release branch.
 

--- a/.agents/skills/pr/SKILL.md
+++ b/.agents/skills/pr/SKILL.md
@@ -1,4 +1,9 @@
-# Pull Request Workflow
+---
+name: pr
+description: 현재 브랜치의 PR을 생성합니다 (label, assignee, milestone, development 자동 설정).
+---
+
+# PR Creation
 
 Use this workflow to create pull requests for feature branches and release branches.
 

--- a/.claude/skills/bump-version/SKILL.md
+++ b/.claude/skills/bump-version/SKILL.md
@@ -6,6 +6,6 @@ argument-hint: <version> (e.g. 1.6.0)
 
 # Version Bump
 
-Follow the shared workflow in `docs/agent-workflows/bump-version.md`.
+Follow the repository skill workflow in `.agents/skills/bump-version/SKILL.md`.
 
 Use the slash-command argument as the target version. Do not commit unless the developer explicitly asks.

--- a/.claude/skills/cleanup/SKILL.md
+++ b/.claude/skills/cleanup/SKILL.md
@@ -5,6 +5,6 @@ description: feature 브랜치 머지 후 로컬 정리 (release 전환, pull, �
 
 # Post-Merge Cleanup
 
-Follow the shared workflow in `docs/agent-workflows/cleanup.md`.
+Follow the repository skill workflow in `.agents/skills/cleanup/SKILL.md`.
 
 Ask the developer if the target release branch cannot be inferred safely.

--- a/.claude/skills/pr/SKILL.md
+++ b/.claude/skills/pr/SKILL.md
@@ -5,6 +5,6 @@ description: 현재 브랜치의 PR을 생성합니다 (label, assignee, milesto
 
 # PR Creation
 
-Follow the shared workflow in `docs/agent-workflows/pr.md`.
+Follow the repository skill workflow in `.agents/skills/pr/SKILL.md`.
 
-Keep Claude-specific generated footers out of shared workflow docs. Add one only when the developer wants it.
+Keep Claude-specific generated footers out of repository skill docs. Add one only when the developer wants it.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -259,7 +259,7 @@ npm run readme:screenshots
 ## Agent Workflow Notes
 
 - Read this file before implementing non-trivial changes.
-- Shared workflow docs live in `docs/agent-workflows/`. Use them for version bumps, PR creation, and post-merge cleanup.
+- Repository-scoped agent skills live in `.agents/skills/`. Use them for version bumps, PR creation, and post-merge cleanup.
 - Keep edits scoped to the issue or user request.
 - Do not revert user changes or unrelated dirty worktree changes.
 - Prefer existing helpers and local patterns over new abstractions.
@@ -271,9 +271,9 @@ npm run readme:screenshots
 
 - `AGENTS.md`: canonical, tool-neutral guide.
 - `CLAUDE.md`: Claude Code compatibility wrapper that imports `AGENTS.md`.
-- `docs/agent-workflows/`: shared workflow docs for agents and humans.
-- `.claude/skills/`: Claude Code slash-command entrypoints. Keep them as wrappers around shared workflows.
-- If a workflow becomes useful to multiple agents, document it in `docs/agent-workflows/` and keep tool-specific files as thin wrappers.
+- `.agents/skills/`: repository-scoped agent skills. Keep reusable agent workflow details here.
+- `.claude/skills/`: Claude Code slash-command entrypoints. Keep them as wrappers around `.agents/skills/`.
+- If a workflow becomes useful to multiple agents, document it as a repository skill in `.agents/skills/` and keep tool-specific files as thin wrappers.
 
 ## Version History
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -6,10 +6,10 @@ Claude Code reads `CLAUDE.md` automatically, while other coding agents may read 
 
 ## Claude Code Skills
 
-Claude-specific slash-command skills remain in `.claude/skills/` and wrap the shared workflow docs in `docs/agent-workflows/`:
+Claude-specific slash-command skills remain in `.claude/skills/` and wrap the repository skills in `.agents/skills/`:
 
-- `/bump-version`: follows `docs/agent-workflows/bump-version.md`.
-- `/pr`: follows `docs/agent-workflows/pr.md`.
-- `/cleanup`: follows `docs/agent-workflows/cleanup.md`.
+- `/bump-version`: follows `.agents/skills/bump-version/SKILL.md`.
+- `/pr`: follows `.agents/skills/pr/SKILL.md`.
+- `/cleanup`: follows `.agents/skills/cleanup/SKILL.md`.
 
-These skills are Claude Code entrypoints, not general project structure. Keep shared workflow details in `docs/agent-workflows/` and keep `.claude/skills/` as Claude wrappers.
+These skills are Claude Code entrypoints, not general project structure. Keep shared workflow details in `.agents/skills/` and keep `.claude/skills/` as Claude wrappers.


### PR DESCRIPTION
## Summary
- Move reusable agent workflows from docs/agent-workflows into repository-scoped .agents skills
- Update AGENTS.md and CLAUDE.md to point to .agents/skills as the canonical workflow location
- Keep Claude slash-command skills as thin wrappers around the repository skills

## Test plan
- [x] Confirmed Codex docs list repository skills under .agents/skills
- [x] Searched for stale docs/agent-workflows references
- [x] Reviewed staged diff and rename detection

No app runtime changes.