### PR TITLE
fix: standardize mode labels

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -41,7 +41,7 @@ import {
   ACHIEVEMENTS,
 } from './lib/achievements'
 import { getEquippedAlertMessageKeys } from './lib/cosmetics'
-import { GameMode } from './lib/gameMode'
+import { CREATE_MODE_LABEL, GAME_MODE_LABELS, GameMode } from './lib/gameMode'
 import { recordCompletedGameProgress } from './lib/achievementProgress'
 import ReactGA from 'react-ga'
 import '@bcgov/bc-sans/css/BCSans.css'
@@ -340,13 +340,20 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
           <h1 className="text-xl font-bold">Wor&#x1F517;dle</h1>
           <p className="text-sm text-gray-500">
             {isDaily ? (
-              <>Daily | {localDateStr}</>
+              <>
+                {GAME_MODE_LABELS.daily} | {localDateStr}
+              </>
             ) : isCustom ? (
               <>
-                <span className="text-green-500">Custom</span> | {questioner}
+                <span className="text-green-500">
+                  {GAME_MODE_LABELS.custom}
+                </span>{' '}
+                | {questioner}
               </>
             ) : (
-              <span className="text-purple-500">{t('practice')}</span>
+              <span className="text-purple-500">
+                {GAME_MODE_LABELS.practice}
+              </span>
             )}
           </p>
         </div>
@@ -446,14 +453,14 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
           to={isDaily ? '/practice' : '/'}
           className="flex items-center px-2.5 py-1.5 border border-transparent text-xs font-medium rounded text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 select-none"
         >
-          {isDaily ? t('practice') : t('daily')}
+          {isDaily ? GAME_MODE_LABELS.practice : GAME_MODE_LABELS.daily}
         </Link>
         {isDaily && (
           <Link
             to="/create"
             className="flex items-center px-2.5 py-1.5 border border-transparent text-xs font-medium rounded text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 select-none"
           >
-            {t('createPuzzleNav')}
+            {CREATE_MODE_LABEL}
           </Link>
         )}
       </div>

--- a/src/components/achievements/AchievementList.tsx
+++ b/src/components/achievements/AchievementList.tsx
@@ -10,7 +10,7 @@ import { loadDailyHistory } from '../../lib/dailyHistory'
 import { loadStats } from '../../lib/stats'
 import { getRewardsForAchievement } from '../../lib/cosmetics'
 import { CosmeticPreview } from '../cosmetics/CosmeticPreview'
-import { GameMode } from '../../lib/gameMode'
+import { GAME_MODE_LABELS, GameMode } from '../../lib/gameMode'
 
 const CATEGORY_ICONS: Record<AchievementCategory, string> = {
   milestone: '\uD83C\uDFAF',
@@ -30,14 +30,14 @@ const ALL_MODE_BADGE_CLASS = 'bg-yellow-50 text-yellow-700 border-yellow-200'
 
 const getModeBadgeItems = (
   modes: GameMode[]
-): Array<{ id: string; labelKey: string; className: string }> => {
+): Array<{ id: string; label: string; className: string }> => {
   const includesAllModes = ALL_MODES.every((mode) => modes.includes(mode))
 
   if (includesAllModes) {
     return [
       {
         id: 'all',
-        labelKey: 'allModes',
+        label: 'All',
         className: ALL_MODE_BADGE_CLASS,
       },
     ]
@@ -45,7 +45,7 @@ const getModeBadgeItems = (
 
   return modes.map((mode) => ({
     id: mode,
-    labelKey: mode,
+    label: GAME_MODE_LABELS[mode],
     className: MODE_BADGE_CLASSES[mode],
   }))
 }
@@ -148,7 +148,7 @@ export const AchievementList = ({ scrollToId }: { scrollToId?: string }) => {
                         key={badge.id}
                         className={`inline-flex items-center rounded-full border px-1.5 py-0.5 text-[0.625rem] font-semibold leading-none ${badge.className}`}
                       >
-                        {t(badge.labelKey)}
+                        {badge.label}
                       </span>
                     )
                   )}

--- a/src/components/pages/CreatePuzzlePage.tsx
+++ b/src/components/pages/CreatePuzzlePage.tsx
@@ -15,6 +15,7 @@ import { InfoModal } from '../modals/InfoModal'
 import { SettingsModal } from '../modals/SettingsModal'
 import { DonateModal } from '../modals/DonateModal'
 import { CONFIG } from '../../constants/config'
+import { CREATE_MODE_LABEL, GAME_MODE_LABELS } from '../../lib/gameMode'
 
 const emptyLetters = () => Array.from({ length: CONFIG.wordLength }, () => '')
 
@@ -26,13 +27,14 @@ export const CreatePuzzlePage = () => {
   const [error, setError] = useState('')
   const [copied, setCopied] = useState(false)
   const [copiedUrl, setCopiedUrl] = useState('')
-  const [isUppercase, setIsUppercase] = useState(() => loadSettings().isUppercase)
+  const [isUppercase, setIsUppercase] = useState(
+    () => loadSettings().isUppercase
+  )
   const [weekStartsOnMonday] = useState(() => loadSettings().weekStartsOnMonday)
   const [excludeUrl, setExcludeUrl] = useState(() => loadSettings().excludeUrl)
   const [isInfoModalOpen, setIsInfoModalOpen] = useState(false)
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false)
   const [isDonateModalOpen, setIsDonateModalOpen] = useState(false)
-
 
   useEffect(() => {
     saveSettings({ isUppercase, weekStartsOnMonday, excludeUrl })
@@ -63,9 +65,7 @@ export const CreatePuzzlePage = () => {
       return
     }
     if (!isFilled) {
-      setError(
-        t('createPuzzleErrorWordLength', { length: CONFIG.wordLength })
-      )
+      setError(t('createPuzzleErrorWordLength', { length: CONFIG.wordLength }))
       return
     }
     const word = getWord().toLowerCase()
@@ -96,8 +96,7 @@ export const CreatePuzzlePage = () => {
     }
   }, [questioner, isFilled, getWord, t])
 
-  const isInputFocused = () =>
-    document.activeElement === nameInputRef.current
+  const isInputFocused = () => document.activeElement === nameInputRef.current
 
   const onChar = useCallback(
     (value: string) => {
@@ -149,7 +148,7 @@ export const CreatePuzzlePage = () => {
       <div className="flex w-80 mx-auto items-center mb-8">
         <div className="grow">
           <h1 className="text-xl font-bold">Wor&#x1F517;dle</h1>
-          <p className="text-sm text-green-500">{t('createPuzzle')}</p>
+          <p className="text-sm text-green-500">{CREATE_MODE_LABEL}</p>
         </div>
         <InformationCircleIcon
           className="h-6 w-6 cursor-pointer"
@@ -213,7 +212,7 @@ export const CreatePuzzlePage = () => {
                     className={classnames(
                       'w-14 h-14 border-solid border-2 flex items-center justify-center mx-0.5 text-lg font-bold rounded text-center outline-none',
                       {
-                        'uppercase': isUppercase,
+                        uppercase: isUppercase,
                         'bg-green-500 text-white border-green-500':
                           copied && letter,
                         'bg-white border-black': !copied && letter,
@@ -235,21 +234,20 @@ export const CreatePuzzlePage = () => {
                 }
               )}
             >
-              {error
-                ? error
-                : copied
-                  ? <>
-                      {t('createPuzzleCopied')}{' '}
-                      <a
-                        href={copiedUrl}
-                        className="underline"
-                      >
-                        ({t('createPuzzleTryIt')})
-                      </a>
-                    </>
-                  : isFilled
-                    ? t('createPuzzleReady')
-                    : t('createPuzzleHint')}
+              {error ? (
+                error
+              ) : copied ? (
+                <>
+                  {t('createPuzzleCopied')}{' '}
+                  <a href={copiedUrl} className="underline">
+                    ({t('createPuzzleTryIt')})
+                  </a>
+                </>
+              ) : isFilled ? (
+                t('createPuzzleReady')
+              ) : (
+                t('createPuzzleHint')
+              )}
             </div>
           </div>
         </div>
@@ -257,9 +255,7 @@ export const CreatePuzzlePage = () => {
           onChar={onChar}
           onDelete={onDelete}
           onEnter={onEnter}
-          guesses={
-            copied ? [getWord().toLowerCase().split('')] : []
-          }
+          guesses={copied ? [getWord().toLowerCase().split('')] : []}
           solution={copied ? getWord().toLowerCase() : ''}
         />
       </div>
@@ -287,7 +283,7 @@ export const CreatePuzzlePage = () => {
           to="/"
           className="flex items-center px-2.5 py-1.5 border border-transparent text-xs font-medium rounded text-indigo-700 bg-indigo-100 hover:bg-indigo-200 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500 select-none"
         >
-          {t('daily')}
+          {GAME_MODE_LABELS.daily}
         </Link>
       </div>
     </div>

--- a/src/lib/gameMode.ts
+++ b/src/lib/gameMode.ts
@@ -1,1 +1,9 @@
 export type GameMode = 'daily' | 'practice' | 'custom'
+
+export const GAME_MODE_LABELS: Record<GameMode, string> = {
+  daily: 'Daily',
+  practice: 'Practice',
+  custom: 'Custom',
+}
+
+export const CREATE_MODE_LABEL = 'Create'


### PR DESCRIPTION
## Summary
- Centralize fixed English labels for game modes.
- Use consistent Daily, Practice, Custom, and Create labels in the header, mode navigation, create page, and achievement mode badges.

Closes #173

## Test plan
- npx prettier --check src/App.tsx src/components/pages/CreatePuzzlePage.tsx src/components/achievements/AchievementList.tsx src/lib/gameMode.ts
- npm test -- --watchAll=false src/App.test.tsx src/lib/achievements.test.ts