### PR TITLE
fix: hide chain preview after completion

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -381,6 +381,7 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
           guesses={guesses}
           currentGuess={currentGuess}
           solution={solution}
+          isGameComplete={isGameWon || isGameLost}
         />
         <Keyboard
           onChar={onChar}

--- a/src/components/grid/Grid.test.tsx
+++ b/src/components/grid/Grid.test.tsx
@@ -1,0 +1,40 @@
+import { render } from '@testing-library/react'
+import { Grid } from './Grid'
+
+const winningGuess = ['c', 'r', 'a', 'n', 'e']
+
+const getRow = (container: HTMLElement, rowIndex: number) => {
+  const elementIndex = rowIndex * 2 + 1
+  const row = container.querySelector(`.pb-6 > div:nth-child(${elementIndex})`)
+
+  if (!row) {
+    throw new Error(`Expected row ${rowIndex} to exist`)
+  }
+
+  return row
+}
+
+test('hides the next row chain letter after game completion', () => {
+  const { container, rerender } = render(
+    <Grid
+      guesses={[winningGuess]}
+      currentGuess={[]}
+      solution="crane"
+      isGameComplete={false}
+    />
+  )
+
+  expect(getRow(container, 1)).toHaveTextContent('e')
+
+  rerender(
+    <Grid
+      guesses={[winningGuess]}
+      currentGuess={[]}
+      solution="crane"
+      isGameComplete
+    />
+  )
+
+  expect(getRow(container, 0)).toHaveTextContent('crane')
+  expect(getRow(container, 1)).not.toHaveTextContent('e')
+})

--- a/src/components/grid/Grid.tsx
+++ b/src/components/grid/Grid.tsx
@@ -9,6 +9,7 @@ type Props = {
   guesses: string[][]
   currentGuess: string[]
   solution: string
+  isGameComplete?: boolean
 }
 
 function getChainPositions(rowIndex: number) {
@@ -31,7 +32,12 @@ function getBridgeChainIndex(rowIndex: number) {
   return rowIndex % 2 === 0 ? CONFIG.wordLength - 1 : 0
 }
 
-export const Grid = ({ guesses, currentGuess, solution }: Props) => {
+export const Grid = ({
+  guesses,
+  currentGuess,
+  solution,
+  isGameComplete = false,
+}: Props) => {
   const elements: React.ReactNode[] = []
 
   for (let i = 0; i < CONFIG.tries; i++) {
@@ -47,7 +53,7 @@ export const Grid = ({ guesses, currentGuess, solution }: Props) => {
           chainBottomIndex={chainBottomIndex}
         />
       )
-    } else if (i === guesses.length) {
+    } else if (i === guesses.length && !isGameComplete) {
       elements.push(
         <CurrentRow
           key={`row-${i}`}
@@ -70,10 +76,7 @@ export const Grid = ({ guesses, currentGuess, solution }: Props) => {
 
     if (i < CONFIG.tries - 1) {
       elements.push(
-        <ChainBridge
-          key={`bridge-${i}`}
-          chainIndex={getBridgeChainIndex(i)}
-        />
+        <ChainBridge key={`bridge-${i}`} chainIndex={getBridgeChainIndex(i)} />
       )
     }
   }


### PR DESCRIPTION
## Summary
- Pass game completion state into the grid.
- Render the next row as an empty row after win/loss so the locked chain letter no longer appears after the game is over.
- Add a focused Grid component test for active vs completed chain preview behavior.

Closes #178

## Test plan
- npx prettier --check src/App.tsx src/components/grid/Grid.tsx src/components/grid/Grid.test.tsx
- npm test -- --watchAll=false src/components/grid/Grid.test.tsx src/App.test.tsx