### PR TITLE
feat: restore calendar week start setting

### DIFF
--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -1,5 +1,10 @@
 import { Temporal } from 'temporal-polyfill'
-import { test, expect, waitForGameReady, screenshot } from './fixtures/game.fixture'
+import {
+  test,
+  expect,
+  waitForGameReady,
+  screenshot,
+} from './fixtures/game.fixture'
 import { Page } from '@playwright/test'
 
 /** Format a date key as "yyyy-mm-dd" */
@@ -9,7 +14,13 @@ const toDateKey = (y: number, m: number, d: number) =>
 /** Inject fake dailyHistory into localStorage and reload */
 async function injectHistory(
   page: Page,
-  entries: { y: number; m: number; d: number; guessCount: number; won: boolean }[]
+  entries: {
+    y: number
+    m: number
+    d: number
+    guessCount: number
+    won: boolean
+  }[]
 ) {
   const history: Record<string, { guessCount: number; won: boolean }> = {}
   let minKey = ''
@@ -52,11 +63,16 @@ test.describe('Calendar', () => {
     // Current month label (e.g. "March 2026") — uses local time
     const today = Temporal.Now.plainDateISO()
     const firstOfMonth = today.with({ day: 1 })
-    const monthLabel = firstOfMonth.toLocaleString('en-US', { month: 'long', year: 'numeric' })
+    const monthLabel = firstOfMonth.toLocaleString('en-US', {
+      month: 'long',
+      year: 'numeric',
+    })
     await expect(gamePage.locator(`text=${monthLabel}`)).toBeVisible()
 
     // Weekday header — Sunday start by default
-    const weekdayHeaders = gamePage.locator('.w-10.text-center.text-xs.font-medium')
+    const weekdayHeaders = gamePage.locator(
+      '.w-10.text-center.text-xs.font-medium'
+    )
     await expect(weekdayHeaders).toHaveCount(7)
     await expect(weekdayHeaders.first()).toHaveText('Su')
     await expect(weekdayHeaders.last()).toHaveText('Sa')
@@ -65,13 +81,17 @@ test.describe('Calendar', () => {
     await expect(gamePage.locator('text=🔥')).toBeVisible()
 
     // Share month button
-    await expect(gamePage.locator('button', { hasText: 'Share month' })).toBeVisible()
+    await expect(
+      gamePage.locator('button', { hasText: 'Share month' })
+    ).toBeVisible()
 
     await screenshot(gamePage, '01-calendar-tab')
 
     // Close via Escape
     await gamePage.keyboard.press('Escape')
-    await expect(gamePage.getByRole('heading', { name: 'Records' })).not.toBeVisible()
+    await expect(
+      gamePage.getByRole('heading', { name: 'Records' })
+    ).not.toBeVisible()
   })
 
   test('displays win and loss indicators', async ({ gamePage }) => {
@@ -103,7 +123,10 @@ test.describe('Calendar', () => {
 
     const today = Temporal.Now.plainDateISO()
     const firstOfMonth = today.with({ day: 1 })
-    const currentLabel = firstOfMonth.toLocaleString('en-US', { month: 'long', year: 'numeric' })
+    const currentLabel = firstOfMonth.toLocaleString('en-US', {
+      month: 'long',
+      year: 'numeric',
+    })
     await expect(gamePage.locator(`text=${currentLabel}`)).toBeVisible()
 
     // Today button disabled on current month
@@ -123,9 +146,41 @@ test.describe('Calendar', () => {
     await screenshot(gamePage, '02-back-to-current')
   })
 
-  // weekStart setting removed in v1.5.0
+  test('week start setting switches calendar to Monday start', async ({
+    gamePage,
+  }) => {
+    await gamePage
+      .locator('svg.h-6.w-6.cursor-pointer')
+      .nth(SETTINGS_ICON)
+      .click()
+    await expect(gamePage.locator('text=Settings')).toBeVisible()
+    await expect(gamePage.locator('text=Start Week on Monday')).toBeVisible()
 
-  test('share button disabled without data, enabled with data', async ({ gamePage }) => {
+    const weekStartToggle = gamePage.locator('button[role="switch"]').nth(1)
+    await expect(weekStartToggle).toHaveAttribute('aria-checked', 'false')
+    await weekStartToggle.click()
+    await expect(weekStartToggle).toHaveAttribute('aria-checked', 'true')
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
+
+    await openCalendarTab(gamePage)
+    const weekdayHeaders = gamePage.locator(
+      '.w-10.text-center.text-xs.font-medium'
+    )
+    await expect(weekdayHeaders.first()).toHaveText('Mo')
+    await expect(weekdayHeaders.last()).toHaveText('Su')
+    await screenshot(gamePage, '01-calendar-monday-start')
+    await gamePage.keyboard.press('Escape')
+
+    await gamePage.reload()
+    await waitForGameReady(gamePage)
+    await openCalendarTab(gamePage)
+    await expect(weekdayHeaders.first()).toHaveText('Mo')
+    await expect(weekdayHeaders.last()).toHaveText('Su')
+  })
+
+  test('share button disabled without data, enabled with data', async ({
+    gamePage,
+  }) => {
     await openCalendarTab(gamePage)
     const shareBtn = gamePage.locator('button', { hasText: 'Share month' })
 
@@ -148,11 +203,15 @@ test.describe('Calendar', () => {
 
     // Click share → success alert
     await shareBtn.click()
-    await expect(gamePage.locator('text=Calendar copied to clipboard')).toBeVisible()
+    await expect(
+      gamePage.locator('text=Calendar copied to clipboard')
+    ).toBeVisible()
     await screenshot(gamePage, '02-share-enabled-and-copied')
   })
 
-  test('stats icon visible in daily, hidden in practice (no calendar tab)', async ({ gamePage }) => {
+  test('stats icon visible in daily, hidden in practice (no calendar tab)', async ({
+    gamePage,
+  }) => {
     // Daily: 4 icons (info, stats, settings, donate)
     await expect(gamePage.locator('svg.h-6.w-6.cursor-pointer')).toHaveCount(4)
 

--- a/e2e/modals.spec.ts
+++ b/e2e/modals.spec.ts
@@ -163,7 +163,7 @@ test.describe('Modals', () => {
     await expect(gamePage.locator('text=Display in Uppercase')).toBeVisible()
     await screenshot(gamePage, '01-settings-modal-open')
 
-    // Toggle uppercase on (first switch = uppercase, second = exclude URL)
+    // Toggle uppercase on (first switch = uppercase)
     const toggle = gamePage.locator('button[role="switch"]').first()
     await toggle.click()
     await screenshot(gamePage, '02-uppercase-toggle-on')

--- a/e2e/share-exclude-url.spec.ts
+++ b/e2e/share-exclude-url.spec.ts
@@ -18,7 +18,9 @@ test.describe('Share — Exclude URL setting', () => {
 
   /** Grant clipboard permissions and navigate to a custom puzzle */
   async function setupCustomGame(gamePage: import('@playwright/test').Page) {
-    await gamePage.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+    await gamePage
+      .context()
+      .grantPermissions(['clipboard-read', 'clipboard-write'])
     await gamePage.goto(customPuzzlePath('crane'))
     await waitForGameReady(gamePage)
   }
@@ -26,13 +28,19 @@ test.describe('Share — Exclude URL setting', () => {
   /** Win the game by typing the correct word, wait for stats modal */
   async function winGame(gamePage: import('@playwright/test').Page) {
     await submitWord(gamePage, 'crane')
-    await expect(gamePage.getByRole('heading', { name: 'Records' })).toBeVisible({ timeout: 5000 })
+    await expect(
+      gamePage.getByRole('heading', { name: 'Records' })
+    ).toBeVisible({ timeout: 5000 })
   }
 
   /** Click the Share button in the stats modal and read clipboard */
-  async function clickShareAndReadClipboard(gamePage: import('@playwright/test').Page): Promise<string> {
+  async function clickShareAndReadClipboard(
+    gamePage: import('@playwright/test').Page
+  ): Promise<string> {
     await gamePage.getByRole('button', { name: 'Share My Result' }).click()
-    await expect(gamePage.locator('text=Game copied to clipboard')).toBeVisible({ timeout: 3000 })
+    await expect(gamePage.locator('text=Game copied to clipboard')).toBeVisible(
+      { timeout: 3000 }
+    )
     return gamePage.evaluate(() => navigator.clipboard.readText())
   }
 
@@ -40,15 +48,20 @@ test.describe('Share — Exclude URL setting', () => {
   async function toggleExcludeUrl(gamePage: import('@playwright/test').Page) {
     // Custom mode: 0:info, 1:settings, 2:donate
     const settingsIndex = 1
-    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(settingsIndex).click()
+    await gamePage
+      .locator('svg.h-6.w-6.cursor-pointer')
+      .nth(settingsIndex)
+      .click()
     await expect(gamePage.locator('text=Settings')).toBeVisible()
-    // Exclude URL is the 2nd toggle (0:uppercase, 1:excludeUrl)
-    await gamePage.locator('button[role="switch"]').nth(1).click()
+    // Exclude URL is the 3rd toggle (0:uppercase, 1:weekStart, 2:excludeUrl)
+    await gamePage.locator('button[role="switch"]').nth(2).click()
     await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
     await expect(gamePage.locator('text=Settings')).not.toBeVisible()
   }
 
-  test('default (excludeUrl off): shared text includes URL', async ({ gamePage }) => {
+  test('default (excludeUrl off): shared text includes URL', async ({
+    gamePage,
+  }) => {
     await setupCustomGame(gamePage)
     await winGame(gamePage)
     await screenshot(gamePage, '01-stats-modal-default')
@@ -61,7 +74,9 @@ test.describe('Share — Exclude URL setting', () => {
     expect(clipboard).toMatch(/\n\n.*localhost/)
   })
 
-  test('excludeUrl on: shared text does NOT include URL', async ({ gamePage }) => {
+  test('excludeUrl on: shared text does NOT include URL', async ({
+    gamePage,
+  }) => {
     await setupCustomGame(gamePage)
 
     // Enable Exclude URL before playing
@@ -79,15 +94,20 @@ test.describe('Share — Exclude URL setting', () => {
   })
 
   test('setting persists after page reload', async ({ gamePage }) => {
-    await gamePage.context().grantPermissions(['clipboard-read', 'clipboard-write'])
+    await gamePage
+      .context()
+      .grantPermissions(['clipboard-read', 'clipboard-write'])
     await gamePage.goto('/')
     await waitForGameReady(gamePage)
 
     // Enable Exclude URL on daily page
-    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(SETTINGS_ICON_DAILY).click()
+    await gamePage
+      .locator('svg.h-6.w-6.cursor-pointer')
+      .nth(SETTINGS_ICON_DAILY)
+      .click()
     await expect(gamePage.locator('text=Settings')).toBeVisible()
-    // Exclude URL is the 2nd toggle (0:uppercase, 1:excludeUrl)
-    const excludeToggle = gamePage.locator('button[role="switch"]').nth(1)
+    // Exclude URL is the 3rd toggle (0:uppercase, 1:weekStart, 2:excludeUrl)
+    const excludeToggle = gamePage.locator('button[role="switch"]').nth(2)
     await expect(excludeToggle).toHaveAttribute('aria-checked', 'false')
     await excludeToggle.click()
     await expect(excludeToggle).toHaveAttribute('aria-checked', 'true')
@@ -99,9 +119,12 @@ test.describe('Share — Exclude URL setting', () => {
     await waitForGameReady(gamePage)
 
     // Reopen settings — toggle should still be on
-    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(SETTINGS_ICON_DAILY).click()
+    await gamePage
+      .locator('svg.h-6.w-6.cursor-pointer')
+      .nth(SETTINGS_ICON_DAILY)
+      .click()
     await expect(gamePage.locator('text=Settings')).toBeVisible()
-    const toggleAfter = gamePage.locator('button[role="switch"]').nth(1)
+    const toggleAfter = gamePage.locator('button[role="switch"]').nth(2)
     await expect(toggleAfter).toHaveAttribute('aria-checked', 'true')
     await screenshot(gamePage, '02-exclude-url-persisted-after-reload')
   })

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -86,7 +86,9 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
   const [isUppercase, setIsUppercase] = useState(
     () => loadSettings().isUppercase
   )
-  const [weekStartsOnMonday] = useState(() => loadSettings().weekStartsOnMonday)
+  const [weekStartsOnMonday, setWeekStartsOnMonday] = useState(
+    () => loadSettings().weekStartsOnMonday
+  )
   const [excludeUrl, setExcludeUrl] = useState(() => loadSettings().excludeUrl)
   const [isWordNotFoundAlertOpen, setIsWordNotFoundAlertOpen] = useState(false)
   const [isGameLost, setIsGameLost] = useState(false)
@@ -429,6 +431,10 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
         handleClose={() => setIsSettingsModalOpen(false)}
         isUppercase={isUppercase}
         onToggleUppercase={() => setIsUppercase(!isUppercase)}
+        weekStartsOnMonday={weekStartsOnMonday}
+        onToggleWeekStartsOnMonday={() =>
+          setWeekStartsOnMonday(!weekStartsOnMonday)
+        }
         excludeUrl={excludeUrl}
         onToggleExcludeUrl={() => setExcludeUrl(!excludeUrl)}
         onNavigateToAchievement={(id) => {

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -34,6 +34,8 @@ type Props = {
   handleClose: () => void
   isUppercase: boolean
   onToggleUppercase: () => void
+  weekStartsOnMonday: boolean
+  onToggleWeekStartsOnMonday: () => void
   excludeUrl: boolean
   onToggleExcludeUrl: () => void
   onNavigateToAchievement?: (achievementId: string) => void
@@ -324,6 +326,8 @@ export const SettingsModal = ({
   handleClose,
   isUppercase,
   onToggleUppercase,
+  weekStartsOnMonday,
+  onToggleWeekStartsOnMonday,
   excludeUrl,
   onToggleExcludeUrl,
   onNavigateToAchievement,
@@ -502,6 +506,15 @@ export const SettingsModal = ({
             {t('uppercaseLabel')}
           </span>
           <Toggle checked={isUppercase} onClick={onToggleUppercase} />
+        </div>
+        <div className="flex items-center justify-between py-2">
+          <span className="text-sm font-medium text-gray-700">
+            {t('weekStartLabel')}
+          </span>
+          <Toggle
+            checked={weekStartsOnMonday}
+            onClick={onToggleWeekStartsOnMonday}
+          />
         </div>
         <div className="flex items-center justify-between py-2">
           <span className="text-sm font-medium text-gray-700">

--- a/src/components/pages/CreatePuzzlePage.tsx
+++ b/src/components/pages/CreatePuzzlePage.tsx
@@ -30,7 +30,9 @@ export const CreatePuzzlePage = () => {
   const [isUppercase, setIsUppercase] = useState(
     () => loadSettings().isUppercase
   )
-  const [weekStartsOnMonday] = useState(() => loadSettings().weekStartsOnMonday)
+  const [weekStartsOnMonday, setWeekStartsOnMonday] = useState(
+    () => loadSettings().weekStartsOnMonday
+  )
   const [excludeUrl, setExcludeUrl] = useState(() => loadSettings().excludeUrl)
   const [isInfoModalOpen, setIsInfoModalOpen] = useState(false)
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false)
@@ -270,6 +272,10 @@ export const CreatePuzzlePage = () => {
         handleClose={() => setIsSettingsModalOpen(false)}
         isUppercase={isUppercase}
         onToggleUppercase={() => setIsUppercase(!isUppercase)}
+        weekStartsOnMonday={weekStartsOnMonday}
+        onToggleWeekStartsOnMonday={() =>
+          setWeekStartsOnMonday(!weekStartsOnMonday)
+        }
         excludeUrl={excludeUrl}
         onToggleExcludeUrl={() => setExcludeUrl(!excludeUrl)}
       />


### PR DESCRIPTION
## Summary
- Restore the Start Week on Monday toggle in Settings.
- Persist and reuse the existing weekStartsOnMonday setting from Daily and Create settings.
- Update Calendar and share-exclude E2E coverage for the new toggle order and Monday-start behavior.

Closes #174

## Test plan
- npx prettier --check src/App.tsx src/components/pages/CreatePuzzlePage.tsx src/components/modals/SettingsModal.tsx e2e/calendar.spec.ts e2e/modals.spec.ts e2e/share-exclude-url.spec.ts
- npm test -- --watchAll=false src/App.test.tsx
- PUBLIC_URL=/ npm run build
- npx playwright test e2e/calendar.spec.ts e2e/share-exclude-url.spec.ts --project=chromium --workers=1 --reporter=list

Note: an initial parallel Playwright run hit a local page-load timeout while starting its webServer; the same build passed when served stably and rerun with one worker.