### PR TITLE
feat: add achievement category slots

### DIFF
--- a/src/components/achievements/AchievementList.tsx
+++ b/src/components/achievements/AchievementList.tsx
@@ -17,6 +17,8 @@ const CATEGORY_ICONS: Record<AchievementCategory, string> = {
   guess: '\uD83C\uDFB2',
   streak: '\uD83D\uDD25',
   event: '\uD83E\uDDE9',
+  collection: '\uD83D\uDDC4\uFE0F',
+  performance: '\uD83D\uDCCA',
 }
 
 const MODE_BADGE_CLASSES: Record<GameMode, string> = {

--- a/src/lib/achievements.ts
+++ b/src/lib/achievements.ts
@@ -13,7 +13,13 @@ import { CharStatus, getGuessStatuses } from './statuses'
 
 // --- Type Definitions ---
 
-export type AchievementCategory = 'milestone' | 'guess' | 'streak' | 'event'
+export type AchievementCategory =
+  | 'milestone'
+  | 'guess'
+  | 'streak'
+  | 'event'
+  | 'collection'
+  | 'performance'
 
 export type AchievementEndReason = 'win' | 'fail' | 'deadEnd'
 


### PR DESCRIPTION
## Summary
- Add `collection` and `performance` achievement categories.
- Add category icons for future collection-completion and performance/stat-based achievements.
- Leave existing achievement definitions unchanged.

Closes #169
Closes #189

## Test plan
- npx prettier --check src/lib/achievements.ts src/components/achievements/AchievementList.tsx
- npm test -- --watchAll=false src/lib/achievements.test.ts