### PR TITLE
feat: add enter validation hints

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -31,7 +31,7 @@ import {
 } from './lib/localStorage'
 
 import { CONFIG, PATCH_NOTES_VERSION } from './constants/config'
-import { getChainInfo, isChainDeadEnd } from './lib/chain'
+import { buildFullGuess, getChainInfo, isChainDeadEnd } from './lib/chain'
 import { ORTHOGRAPHY_PATTERN } from './lib/tokenizer'
 import {
   DeadEndContext,
@@ -94,6 +94,9 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
   const [hideLetters, setHideLetters] = useState(
     () => loadSettings().hideLetters
   )
+  const [enterValidationHint, setEnterValidationHint] = useState(
+    () => loadSettings().enterValidationHint
+  )
   const [resultHideLettersOverride, setResultHideLettersOverride] = useState<
     boolean | undefined
   >(undefined)
@@ -153,8 +156,20 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
   }, [guesses, isDaily, solution])
 
   useEffect(() => {
-    saveSettings({ isUppercase, weekStartsOnMonday, excludeUrl, hideLetters })
-  }, [isUppercase, weekStartsOnMonday, excludeUrl, hideLetters])
+    saveSettings({
+      isUppercase,
+      weekStartsOnMonday,
+      excludeUrl,
+      hideLetters,
+      enterValidationHint,
+    })
+  }, [
+    isUppercase,
+    weekStartsOnMonday,
+    excludeUrl,
+    hideLetters,
+    enterValidationHint,
+  ])
 
   useEffect(() => {
     if (!isGameWon && !isGameLost) {
@@ -250,12 +265,7 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
       return
     }
 
-    const chainInfo = getChainInfo(guesses)
-    const fullGuess = chainInfo
-      ? chainInfo.position === 'first'
-        ? [chainInfo.letter, ...currentGuess]
-        : [...currentGuess, chainInfo.letter]
-      : currentGuess
+    const fullGuess = buildFullGuess(currentGuess, guesses)
 
     if (fullGuess.length !== CONFIG.wordLength) {
       setIsNotEnoughLetters(true)
@@ -348,6 +358,14 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
   }
   const localDateStr = dateToKey(Temporal.Now.plainDateISO())
   const effectiveHideLetters = resultHideLettersOverride ?? hideLetters
+  const enterHint = (() => {
+    if (!enterValidationHint || isGameWon || isGameLost) return undefined
+
+    const fullGuess = buildFullGuess(currentGuess, guesses)
+    if (fullGuess.length !== CONFIG.wordLength) return 'incomplete'
+    if (!isWordInWordList(fullGuess.join(''))) return 'invalid'
+    return 'valid'
+  })()
 
   return (
     <div className="py-8 max-w-7xl mx-auto sm:px-6 lg:px-8">
@@ -409,6 +427,7 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
           onEnter={onEnter}
           guesses={guesses}
           solution={solution}
+          enterHint={enterHint}
         />
       </div>
       <InfoModal
@@ -467,6 +486,10 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
         onToggleExcludeUrl={() => setExcludeUrl(!excludeUrl)}
         hideLetters={hideLetters}
         onToggleHideLetters={() => setHideLetters(!hideLetters)}
+        enterValidationHint={enterValidationHint}
+        onToggleEnterValidationHint={() =>
+          setEnterValidationHint(!enterValidationHint)
+        }
         onNavigateToAchievement={(id) => {
           setIsSettingsModalOpen(false)
           setStatsInitialTab('achievements')

--- a/src/components/keyboard/Key.tsx
+++ b/src/components/keyboard/Key.tsx
@@ -3,17 +3,21 @@ import classnames from 'classnames'
 import { KeyValue } from '../../lib/keyboard'
 import { CharStatus } from '../../lib/statuses'
 
+export type KeyVariant = 'incomplete' | 'invalid' | 'valid'
+
 type Props = {
   children?: ReactNode
   value: KeyValue
   width?: number
   status?: CharStatus
+  variant?: KeyVariant
   onClick: (value: KeyValue) => void
 }
 
 export const Key = ({
   children,
   status,
+  variant,
   width = 40,
   value,
   onClick,
@@ -21,12 +25,19 @@ export const Key = ({
   const classes = classnames(
     'flex items-center justify-center rounded mx-0.5 text-xs font-bold cursor-pointer select-none',
     {
-      'bg-slate-200 hover:bg-slate-300 active:bg-slate-400': !status,
+      'bg-slate-200 hover:bg-slate-300 active:bg-slate-400':
+        !status && !variant,
       'bg-slate-400 text-white': status === 'absent',
       'bg-green-500 hover:bg-green-600 active:bg-green-700 text-white':
         status === 'correct',
       'bg-purple-500 hover:bg-purple-600 active:bg-purple-700 text-white':
         status === 'present',
+      'bg-slate-100 text-slate-500 border border-slate-300 hover:bg-slate-200 active:bg-slate-300':
+        variant === 'incomplete',
+      'bg-purple-100 text-purple-700 border border-purple-300 hover:bg-purple-200 active:bg-purple-300':
+        variant === 'invalid',
+      'bg-green-100 text-green-700 border border-green-300 hover:bg-green-200 active:bg-green-300':
+        variant === 'valid',
     }
   )
 

--- a/src/components/keyboard/Keyboard.test.tsx
+++ b/src/components/keyboard/Keyboard.test.tsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react'
+import { Keyboard } from './Keyboard'
+import '../../i18n'
+
+const noop = () => undefined
+
+const renderKeyboard = (enterHint?: 'incomplete' | 'invalid' | 'valid') =>
+  render(
+    <Keyboard
+      onChar={noop}
+      onDelete={noop}
+      onEnter={noop}
+      guesses={[]}
+      solution="crane"
+      enterHint={enterHint}
+    />
+  )
+
+test('keeps the Enter key default style without a validation hint', () => {
+  renderKeyboard()
+
+  expect(screen.getByRole('button', { name: 'Enter' })).toHaveClass(
+    'bg-slate-200'
+  )
+})
+
+test('shows Enter key validation hint variants', () => {
+  const { rerender } = renderKeyboard('incomplete')
+
+  expect(screen.getByRole('button', { name: 'Enter' })).toHaveClass(
+    'bg-slate-100'
+  )
+
+  rerender(
+    <Keyboard
+      onChar={noop}
+      onDelete={noop}
+      onEnter={noop}
+      guesses={[]}
+      solution="crane"
+      enterHint="invalid"
+    />
+  )
+  expect(screen.getByRole('button', { name: 'Enter' })).toHaveClass(
+    'bg-purple-100'
+  )
+
+  rerender(
+    <Keyboard
+      onChar={noop}
+      onDelete={noop}
+      onEnter={noop}
+      guesses={[]}
+      solution="crane"
+      enterHint="valid"
+    />
+  )
+  expect(screen.getByRole('button', { name: 'Enter' })).toHaveClass(
+    'bg-green-100'
+  )
+})

--- a/src/components/keyboard/Keyboard.tsx
+++ b/src/components/keyboard/Keyboard.tsx
@@ -1,6 +1,6 @@
 import { KeyValue } from '../../lib/keyboard'
 import { getStatuses } from '../../lib/statuses'
-import { Key } from './Key'
+import { Key, KeyVariant } from './Key'
 import { useEffect } from 'react'
 import { useTranslation } from 'react-i18next'
 
@@ -16,6 +16,7 @@ type Props = {
   onEnter: () => void
   guesses: string[][]
   solution: string
+  enterHint?: KeyVariant
 }
 
 export const Keyboard = ({
@@ -24,6 +25,7 @@ export const Keyboard = ({
   onEnter,
   guesses,
   solution,
+  enterHint,
 }: Props) => {
   const { t } = useTranslation()
   const charStatuses = getStatuses(guesses, solution)
@@ -78,7 +80,13 @@ export const Keyboard = ({
         ))}
       </div>
       <div className="flex justify-center">
-        <Key key="enterKey" width={65.4} value="ENTER" onClick={onClick}>
+        <Key
+          key="enterKey"
+          width={65.4}
+          value="ENTER"
+          onClick={onClick}
+          variant={enterHint}
+        >
           {t('enterKey')}
         </Key>
         {KEYBOARD_ROWS[2].map((char) => (

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -40,6 +40,8 @@ type Props = {
   onToggleExcludeUrl: () => void
   hideLetters: boolean
   onToggleHideLetters: () => void
+  enterValidationHint: boolean
+  onToggleEnterValidationHint: () => void
   onNavigateToAchievement?: (achievementId: string) => void
 }
 
@@ -334,6 +336,8 @@ export const SettingsModal = ({
   onToggleExcludeUrl,
   hideLetters,
   onToggleHideLetters,
+  enterValidationHint,
+  onToggleEnterValidationHint,
   onNavigateToAchievement,
 }: Props) => {
   const { t, i18n } = useTranslation()
@@ -531,6 +535,15 @@ export const SettingsModal = ({
             {t('hideLettersLabel')}
           </span>
           <Toggle checked={hideLetters} onClick={onToggleHideLetters} />
+        </div>
+        <div className="flex items-center justify-between py-2">
+          <span className="text-sm font-medium text-gray-700">
+            {t('enterValidationHintLabel')}
+          </span>
+          <Toggle
+            checked={enterValidationHint}
+            onClick={onToggleEnterValidationHint}
+          />
         </div>
 
         {/* Cosmetic pickers */}

--- a/src/components/pages/CreatePuzzlePage.tsx
+++ b/src/components/pages/CreatePuzzlePage.tsx
@@ -37,13 +37,28 @@ export const CreatePuzzlePage = () => {
   const [hideLetters, setHideLetters] = useState(
     () => loadSettings().hideLetters
   )
+  const [enterValidationHint, setEnterValidationHint] = useState(
+    () => loadSettings().enterValidationHint
+  )
   const [isInfoModalOpen, setIsInfoModalOpen] = useState(false)
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false)
   const [isDonateModalOpen, setIsDonateModalOpen] = useState(false)
 
   useEffect(() => {
-    saveSettings({ isUppercase, weekStartsOnMonday, excludeUrl, hideLetters })
-  }, [isUppercase, weekStartsOnMonday, excludeUrl, hideLetters])
+    saveSettings({
+      isUppercase,
+      weekStartsOnMonday,
+      excludeUrl,
+      hideLetters,
+      enterValidationHint,
+    })
+  }, [
+    isUppercase,
+    weekStartsOnMonday,
+    excludeUrl,
+    hideLetters,
+    enterValidationHint,
+  ])
 
   const fallbackCopy = (text: string) => {
     const textarea = document.createElement('textarea')
@@ -283,6 +298,10 @@ export const CreatePuzzlePage = () => {
         onToggleExcludeUrl={() => setExcludeUrl(!excludeUrl)}
         hideLetters={hideLetters}
         onToggleHideLetters={() => setHideLetters(!hideLetters)}
+        enterValidationHint={enterValidationHint}
+        onToggleEnterValidationHint={() =>
+          setEnterValidationHint(!enterValidationHint)
+        }
       />
       <DonateModal
         isOpen={isDonateModalOpen}

--- a/src/lib/chain.ts
+++ b/src/lib/chain.ts
@@ -14,13 +14,24 @@ export function getChainInfo(guesses: string[][]): ChainInfo | null {
   }
 }
 
+export function buildFullGuess(
+  currentGuess: string[],
+  guesses: string[][]
+): string[] {
+  const chainInfo = getChainInfo(guesses)
+  if (!chainInfo) return currentGuess
+
+  return chainInfo.position === 'first'
+    ? [chainInfo.letter, ...currentGuess]
+    : [...currentGuess, chainInfo.letter]
+}
+
 export function isChainDeadEnd(
   guesses: string[][],
   solutionChars: string[]
 ): boolean {
   const chainInfo = getChainInfo(guesses)
   if (!chainInfo) return false
-  const chainPos =
-    chainInfo.position === 'first' ? 0 : CONFIG.wordLength - 1
+  const chainPos = chainInfo.position === 'first' ? 0 : CONFIG.wordLength - 1
   return solutionChars[chainPos] !== chainInfo.letter
 }

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -44,6 +44,7 @@ export type Settings = {
   weekStartsOnMonday: boolean
   excludeUrl: boolean
   hideLetters: boolean
+  enterValidationHint: boolean
 }
 
 export const saveSettings = (settings: Settings) => {
@@ -57,6 +58,7 @@ export const loadSettings = (): Settings => {
     weekStartsOnMonday: false,
     excludeUrl: false,
     hideLetters: false,
+    enterValidationHint: false,
   }
   return settings
     ? { ...defaults, ...(JSON.parse(settings) as Partial<Settings>) }

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -38,6 +38,7 @@
   "hideLettersLabel": "Buchstaben im Brett ausblenden",
   "hideLetters": "Buchstaben ausblenden",
   "showLetters": "Buchstaben anzeigen",
+  "enterValidationHintLabel": "Enter-Hinweise anzeigen",
   "donate": "Spenden",
   "donateMonsterDrink": "Spendiere dem Entwickler einen Monster Energy!",
   "donateKakaoPay": "Über KakaoPay spenden",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -38,6 +38,7 @@
   "hideLettersLabel": "Hide Letters on Board",
   "hideLetters": "Hide Letters",
   "showLetters": "Show Letters",
+  "enterValidationHintLabel": "Show Enter Hints",
   "donate": "Donate",
   "donateMonsterDrink": "Buy the developer a Monster Energy!",
   "donateKakaoPay": "Donate via KakaoPay",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -35,6 +35,7 @@
   "hideLettersLabel": "Ocultar letras del tablero",
   "hideLetters": "Ocultar letras",
   "showLetters": "Mostrar letras",
+  "enterValidationHintLabel": "Mostrar pistas de Enter",
   "donate": "Donar",
   "donateMonsterDrink": "¡Cómprale una lata de Monster Energy al desarrollador!",
   "donateKakaoPay": "Donar con KakaoPay",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -38,6 +38,7 @@
   "hideLettersLabel": "ボードの文字を隠す",
   "hideLetters": "文字を隠す",
   "showLetters": "文字を表示",
+  "enterValidationHintLabel": "入力ボタンのヒントを表示",
   "donate": "寄付",
   "donateMonsterDrink": "開発者にモンスターエナジーを1本おごってください！",
   "donateKakaoPay": "KakaoPayで寄付",

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -38,6 +38,7 @@
   "hideLettersLabel": "보드 글자 숨김",
   "hideLetters": "글자 숨기기",
   "showLetters": "글자 보이기",
+  "enterValidationHintLabel": "입력 버튼 힌트 표시",
   "donate": "후원",
   "donateMonsterDrink": "개발자에게 몬스터 에너지 한 캔 사주세요!",
   "donateKakaoPay": "카카오페이로 후원",

--- a/src/locales/sw/translation.json
+++ b/src/locales/sw/translation.json
@@ -35,6 +35,7 @@
   "hideLettersLabel": "Ficha herufi ubaoni",
   "hideLetters": "Ficha herufi",
   "showLetters": "Onyesha herufi",
+  "enterValidationHintLabel": "Onyesha vidokezo vya Enter",
   "donate": "Changia",
   "donateMonsterDrink": "Mnunulie msanidi kopo la Monster Energy!",
   "donateKakaoPay": "Changia kupitia KakaoPay",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -35,6 +35,7 @@
   "hideLettersLabel": "隐藏棋盘字母",
   "hideLetters": "隐藏字母",
   "showLetters": "显示字母",
+  "enterValidationHintLabel": "显示 Enter 提示",
   "donate": "捐贈",
   "donateMonsterDrink": "请给开发者买一罐Monster Energy！",
   "donateKakaoPay": "通过KakaoPay捐赠",


### PR DESCRIPTION
## Summary
- Add a persisted Settings toggle for optional Enter validation hints.
- Reuse chain-aware full-guess construction so the Enter key can show incomplete, invalid, or valid visual states without changing submit behavior.
- Add keyboard variant tests and locale strings.

Closes #179

## Test plan
- npm test -- --watchAll=false --runTestsByPath src/components/keyboard/Keyboard.test.tsx src/components/grid/Grid.test.tsx
- npm test -- --watchAll=false
- PUBLIC_URL=/ npm run build

Note: npm run lint still reports pre-existing Prettier issues in files outside this change scope.