### PR TITLE
refactor: centralize release and reward metadata

### DIFF
--- a/src/components/achievements/AchievementList.tsx
+++ b/src/components/achievements/AchievementList.tsx
@@ -11,6 +11,7 @@ import { loadStats } from '../../lib/stats'
 import { getRewardsForAchievement } from '../../lib/cosmetics'
 import { CosmeticPreview } from '../cosmetics/CosmeticPreview'
 import { GAME_MODE_LABELS, GameMode } from '../../lib/gameMode'
+import { getRewardMetadataLabel } from '../../lib/rewardMetadata'
 
 const CATEGORY_ICONS: Record<AchievementCategory, string> = {
   milestone: '\uD83C\uDFAF',
@@ -205,6 +206,11 @@ export const AchievementList = ({
                 current={achievement.currentProgress.current}
                 target={achievement.currentProgress.target}
               />
+              {achievement.metadata && (
+                <div className="mt-0.5 text-right text-[0.625rem] text-gray-400">
+                  {getRewardMetadataLabel(achievement.metadata)}
+                </div>
+              )}
             </div>
           </div>
         </div>

--- a/src/components/modals/PatchNotesContent.tsx
+++ b/src/components/modals/PatchNotesContent.tsx
@@ -1,163 +1,17 @@
 import { Disclosure } from '@headlessui/react'
 import { ChevronDownIcon } from '@heroicons/react/outline'
 import { PATCH_NOTES_VERSION } from '../../constants/config'
+import {
+  getCurrentPatchNotes,
+  getPatchNoteVersions,
+} from '../../lib/patchNotes'
+import type { PatchNoteFeature } from '../../lib/patchNotes'
 import { useTranslation } from 'react-i18next'
 
-type Feature = {
-  icon: string
-  titleKey: string
-  descKey: string
-  sub?: { icon: string; titleKey: string; descKey: string }[]
-}
+const patchNoteVersions = getPatchNoteVersions()
+const currentPatchNotes = getCurrentPatchNotes(PATCH_NOTES_VERSION)
 
-type PatchNoteVersion = {
-  version: string
-  releasedAt: string
-  features: Feature[]
-}
-
-const patchNoteVersions: PatchNoteVersion[] = [
-  {
-    version: '1.6.0',
-    releasedAt: '2026-05-10',
-    features: [
-      {
-        icon: '📝',
-        titleKey: 'patchNote_updateHistory_title',
-        descKey: 'patchNote_updateHistory_desc',
-      },
-      {
-        icon: '🏷️',
-        titleKey: 'patchNote_shareBadges_title',
-        descKey: 'patchNote_shareBadges_desc',
-      },
-      {
-        icon: '🧩',
-        titleKey: 'patchNote_newAchievements_title',
-        descKey: 'patchNote_newAchievements_desc',
-      },
-      {
-        icon: '🍚',
-        titleKey: 'patchNote_recipeEmoji_title',
-        descKey: 'patchNote_recipeEmoji_desc',
-      },
-    ],
-  },
-  {
-    version: '1.5.0',
-    releasedAt: '2026-04-20',
-    features: [
-      {
-        icon: '🏆',
-        titleKey: 'patchNote_achievements_title',
-        descKey: 'patchNote_achievements_desc',
-      },
-      {
-        icon: '🎨',
-        titleKey: 'patchNote_cosmetics_title',
-        descKey: 'patchNote_cosmetics_desc',
-      },
-      {
-        icon: '🇩🇪',
-        titleKey: 'patchNote_german_title',
-        descKey: 'patchNote_german_desc',
-      },
-      {
-        icon: '🔧',
-        titleKey: 'patchNote_uiFixes_title',
-        descKey: 'patchNote_uiFixes_desc',
-      },
-    ],
-  },
-  {
-    version: '1.4.0',
-    releasedAt: '2026-03-12',
-    features: [
-      {
-        icon: '🕛',
-        titleKey: 'patchNote_localTimezone_title',
-        descKey: 'patchNote_localTimezone_desc',
-      },
-      {
-        icon: '🧭',
-        titleKey: 'patchNote_uiRefactor_title',
-        descKey: 'patchNote_uiRefactor_desc',
-      },
-      {
-        icon: '💖',
-        titleKey: 'patchNote_sponsors_title',
-        descKey: 'patchNote_sponsors_desc',
-      },
-    ],
-  },
-  {
-    version: '1.3.0',
-    releasedAt: '2026-03-07',
-    features: [
-      {
-        icon: '📅',
-        titleKey: 'patchNote_calendar_title',
-        descKey: 'patchNote_calendar_desc',
-      },
-    ],
-  },
-  {
-    version: '1.2.0',
-    releasedAt: '2026-02-28',
-    features: [
-      {
-        icon: '🧩',
-        titleKey: 'patchNote_customPuzzle_title',
-        descKey: 'patchNote_customPuzzle_desc',
-      },
-      {
-        icon: '💝',
-        titleKey: 'patchNote_donations_title',
-        descKey: 'patchNote_donations_desc',
-        sub: [
-          {
-            icon: '💛',
-            titleKey: 'patchNote_kakaopay_title',
-            descKey: 'patchNote_kakaopay_desc',
-          },
-          {
-            icon: '💙',
-            titleKey: 'patchNote_tosspay_title',
-            descKey: 'patchNote_tosspay_desc',
-          },
-        ],
-      },
-      {
-        icon: 'ℹ️',
-        titleKey: 'patchNote_infoModal_title',
-        descKey: 'patchNote_infoModal_desc',
-      },
-      {
-        icon: '✨',
-        titleKey: 'patchNote_ui_title',
-        descKey: 'patchNote_ui_desc',
-        sub: [
-          {
-            icon: '🏷️',
-            titleKey: 'patchNote_subtitle_title',
-            descKey: 'patchNote_subtitle_desc',
-          },
-          {
-            icon: '🏳️',
-            titleKey: 'patchNote_flags_title',
-            descKey: 'patchNote_flags_desc',
-          },
-        ],
-      },
-    ],
-  },
-]
-
-const currentPatchNotes =
-  patchNoteVersions.find(({ version }) => version === PATCH_NOTES_VERSION) ??
-  patchNoteVersions[0]
-
-const PatchNoteFeatureCard = ({ feature }: { feature: Feature }) => {
+const PatchNoteFeatureCard = ({ feature }: { feature: PatchNoteFeature }) => {
   const { t } = useTranslation()
   const { icon, titleKey, descKey, sub } = feature
 

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -7,6 +7,7 @@ import { localeLanguageKey } from '../../i18n'
 import { CompletedRow } from '../grid/CompletedRow'
 import { ChainBridge } from '../grid/ChainBridge'
 import { generateShareText } from '../../lib/share'
+import { getRewardMetadataLabel } from '../../lib/rewardMetadata'
 import { Temporal } from 'temporal-polyfill'
 import {
   COSMETIC_OPTIONS,
@@ -105,6 +106,8 @@ const CosmeticPicker = ({
   )
 
   const equippedOption = options.find((o) => o.id === equipped)
+  const getOptionMetadataLabel = (option: typeof COSMETIC_OPTIONS[number]) =>
+    getRewardMetadataLabel(option.metadata)
 
   return (
     <>
@@ -172,8 +175,13 @@ const CosmeticPicker = ({
                   <span className="flex-shrink-0 flex items-center">
                     {renderPreview(option.id)}
                   </span>
-                  <span className="flex-1 text-right">
-                    {t(option.titleKey)}
+                  <span className="flex-1 text-right min-w-0">
+                    <span className="block truncate">{t(option.titleKey)}</span>
+                    {getOptionMetadataLabel(option) && (
+                      <span className="block text-[0.625rem] leading-tight text-gray-400">
+                        {getOptionMetadataLabel(option)}
+                      </span>
+                    )}
                   </span>
                   <span className="w-5 text-center flex-shrink-0">
                     {!unlocked && '\uD83D\uDD12'}
@@ -231,13 +239,20 @@ const CosmeticPicker = ({
                   >
                     {'<'}
                   </button>
-                  <span
-                    className={`text-sm font-semibold ${
-                      selected ? 'text-indigo-600' : 'text-gray-900'
-                    }`}
-                  >
-                    {MSG_THEME_EMOJI[currentOption.id] || ''}{' '}
-                    {t(currentOption.titleKey)}
+                  <span className="min-w-0 text-center">
+                    <span
+                      className={`block truncate text-sm font-semibold ${
+                        selected ? 'text-indigo-600' : 'text-gray-900'
+                      }`}
+                    >
+                      {MSG_THEME_EMOJI[currentOption.id] || ''}{' '}
+                      {t(currentOption.titleKey)}
+                    </span>
+                    {getOptionMetadataLabel(currentOption) && (
+                      <span className="block text-[0.625rem] leading-tight text-gray-400">
+                        {getOptionMetadataLabel(currentOption)}
+                      </span>
+                    )}
                   </span>
                   <button
                     type="button"

--- a/src/lib/achievements.ts
+++ b/src/lib/achievements.ts
@@ -10,6 +10,7 @@ import {
   loadAchievementProgress,
 } from './achievementProgress'
 import { CharStatus, getGuessStatuses } from './statuses'
+import { REWARD_METADATA, RewardMetadata } from './rewardMetadata'
 
 // --- Type Definitions ---
 
@@ -58,6 +59,7 @@ export type AchievementDef = {
   category: AchievementCategory
   modes?: GameMode[]
   difficulty: number // 1-10, UI에서 별 5개로 매핑 (2당 별 1개)
+  metadata?: RewardMetadata
   progress: (ctx: AchievementContext) => AchievementProgress
   titleKey: string
   descriptionKey: string
@@ -109,6 +111,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'milestone',
     modes: ['daily'],
     difficulty: 1,
+    metadata: REWARD_METADATA.v1_5_0,
     titleKey: 'achievement_play_10_title',
     descriptionKey: 'achievement_play_10_desc',
     progress: ({ stats }) => ({ current: stats.totalGames, target: 10 }),
@@ -118,6 +121,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'milestone',
     modes: ['daily'],
     difficulty: 4,
+    metadata: REWARD_METADATA.v1_5_0,
     titleKey: 'achievement_play_50_title',
     descriptionKey: 'achievement_play_50_desc',
     progress: ({ stats }) => ({ current: stats.totalGames, target: 50 }),
@@ -127,6 +131,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'milestone',
     modes: ['daily'],
     difficulty: 6,
+    metadata: REWARD_METADATA.v1_5_0,
     titleKey: 'achievement_play_100_title',
     descriptionKey: 'achievement_play_100_desc',
     progress: ({ stats }) => ({ current: stats.totalGames, target: 100 }),
@@ -136,6 +141,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'milestone',
     modes: ['daily'],
     difficulty: 8,
+    metadata: REWARD_METADATA.v1_6_0,
     titleKey: 'achievement_play_150_title',
     descriptionKey: 'achievement_play_150_desc',
     progress: ({ stats }) => ({ current: stats.totalGames, target: 150 }),
@@ -145,6 +151,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'milestone',
     modes: ['daily'],
     difficulty: 8,
+    metadata: REWARD_METADATA.v1_6_0,
     titleKey: 'achievement_fail_100_title',
     descriptionKey: 'achievement_fail_100_desc',
     progress: ({ stats }) => ({ current: stats.gamesFailed, target: 100 }),
@@ -154,6 +161,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'milestone',
     modes: ['daily'],
     difficulty: 9,
+    metadata: REWARD_METADATA.v1_6_0,
     titleKey: 'achievement_monthly_attendance_title',
     descriptionKey: 'achievement_monthly_attendance_desc',
     progress: ({ dailyHistory }) =>
@@ -166,6 +174,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'milestone',
     modes: ['daily', 'practice', 'custom'],
     difficulty: 1,
+    metadata: REWARD_METADATA.v1_6_0,
     titleKey: 'achievement_played_v1_6_0_5_title',
     descriptionKey: 'achievement_played_v1_6_0_5_desc',
     progress: ({ progress }) => ({
@@ -178,6 +187,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'milestone',
     modes: ['daily', 'practice', 'custom'],
     difficulty: 1,
+    metadata: REWARD_METADATA.v1_7_0,
     titleKey: 'achievement_played_v1_7_0_5_title',
     descriptionKey: 'achievement_played_v1_7_0_5_desc',
     progress: ({ progress }) => ({
@@ -190,6 +200,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'milestone',
     modes: ['practice'],
     difficulty: 8,
+    metadata: REWARD_METADATA.v1_6_0,
     titleKey: 'achievement_practice_win_100_title',
     descriptionKey: 'achievement_practice_win_100_desc',
     progress: ({ progress }) => ({
@@ -202,6 +213,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'milestone',
     modes: ['custom'],
     difficulty: 4,
+    metadata: REWARD_METADATA.v1_6_0,
     titleKey: 'achievement_custom_win_10_title',
     descriptionKey: 'achievement_custom_win_10_desc',
     progress: ({ progress }) => ({
@@ -216,6 +228,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'guess',
     modes: ['daily'],
     difficulty: 10,
+    metadata: REWARD_METADATA.v1_5_0,
     titleKey: 'achievement_win_in_1_title',
     descriptionKey: 'achievement_win_in_1_desc',
     progress: ({ stats }) => ({ current: stats.winDistribution[0], target: 1 }),
@@ -225,6 +238,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'guess',
     modes: ['daily'],
     difficulty: 9,
+    metadata: REWARD_METADATA.v1_5_0,
     titleKey: 'achievement_win_in_2_title',
     descriptionKey: 'achievement_win_in_2_desc',
     progress: ({ stats }) => ({ current: stats.winDistribution[1], target: 2 }),
@@ -234,6 +248,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'guess',
     modes: ['daily'],
     difficulty: 7,
+    metadata: REWARD_METADATA.v1_5_0,
     titleKey: 'achievement_win_in_3_title',
     descriptionKey: 'achievement_win_in_3_desc',
     progress: ({ stats }) => ({ current: stats.winDistribution[2], target: 3 }),
@@ -243,6 +258,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'guess',
     modes: ['daily'],
     difficulty: 6,
+    metadata: REWARD_METADATA.v1_5_0,
     titleKey: 'achievement_win_in_4_title',
     descriptionKey: 'achievement_win_in_4_desc',
     progress: ({ stats }) => ({ current: stats.winDistribution[3], target: 4 }),
@@ -252,6 +268,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'guess',
     modes: ['daily'],
     difficulty: 4,
+    metadata: REWARD_METADATA.v1_5_0,
     titleKey: 'achievement_win_in_5_title',
     descriptionKey: 'achievement_win_in_5_desc',
     progress: ({ stats }) => ({ current: stats.winDistribution[4], target: 5 }),
@@ -261,6 +278,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'guess',
     modes: ['daily'],
     difficulty: 3,
+    metadata: REWARD_METADATA.v1_5_0,
     titleKey: 'achievement_win_in_6_title',
     descriptionKey: 'achievement_win_in_6_desc',
     progress: ({ stats }) => ({ current: stats.winDistribution[5], target: 6 }),
@@ -270,6 +288,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'guess',
     modes: ['daily'],
     difficulty: 6,
+    metadata: REWARD_METADATA.v1_7_0,
     titleKey: 'achievement_win_in_6_20_title',
     descriptionKey: 'achievement_win_in_6_20_desc',
     progress: ({ stats }) => ({
@@ -284,6 +303,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'streak',
     modes: ['daily'],
     difficulty: 3,
+    metadata: REWARD_METADATA.v1_5_0,
     titleKey: 'achievement_streak_3_title',
     descriptionKey: 'achievement_streak_3_desc',
     progress: ({ stats }) => ({ current: stats.bestStreak, target: 3 }),
@@ -293,6 +313,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'streak',
     modes: ['daily'],
     difficulty: 5,
+    metadata: REWARD_METADATA.v1_7_0,
     titleKey: 'achievement_streak_5_title',
     descriptionKey: 'achievement_streak_5_desc',
     progress: ({ stats }) => ({ current: stats.bestStreak, target: 5 }),
@@ -302,6 +323,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'streak',
     modes: ['daily'],
     difficulty: 6,
+    metadata: REWARD_METADATA.v1_5_0,
     titleKey: 'achievement_streak_7_title',
     descriptionKey: 'achievement_streak_7_desc',
     progress: ({ stats }) => ({ current: stats.bestStreak, target: 7 }),
@@ -311,6 +333,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'streak',
     modes: ['daily'],
     difficulty: 8,
+    metadata: REWARD_METADATA.v1_6_0,
     titleKey: 'achievement_streak_14_title',
     descriptionKey: 'achievement_streak_14_desc',
     progress: ({ stats }) => ({ current: stats.bestStreak, target: 14 }),
@@ -320,6 +343,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'streak',
     modes: ['daily'],
     difficulty: 10,
+    metadata: REWARD_METADATA.v1_5_0,
     titleKey: 'achievement_streak_30_title',
     descriptionKey: 'achievement_streak_30_desc',
     progress: ({ stats }) => ({ current: stats.bestStreak, target: 30 }),
@@ -331,6 +355,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'event',
     modes: ['daily'],
     difficulty: 7,
+    metadata: REWARD_METADATA.v1_6_0,
     titleKey: 'achievement_dead_end_tail_title',
     descriptionKey: 'achievement_dead_end_tail_desc',
     progress: ({ game }) => ({
@@ -347,6 +372,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     id: 'bibimbap_balance',
     category: 'event',
     difficulty: 9,
+    metadata: REWARD_METADATA.v1_6_0,
     titleKey: 'achievement_bibimbap_balance_title',
     descriptionKey: 'achievement_bibimbap_balance_desc',
     progress: ({ game }) => {
@@ -368,6 +394,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     id: 'yogurt_recipe',
     category: 'event',
     difficulty: 6,
+    metadata: REWARD_METADATA.v1_6_0,
     titleKey: 'achievement_yogurt_recipe_title',
     descriptionKey: 'achievement_yogurt_recipe_desc',
     progress: ({ game }) => ({
@@ -381,6 +408,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'performance',
     modes: ['daily'],
     difficulty: 5,
+    metadata: REWARD_METADATA.v1_7_0,
     titleKey: 'achievement_no_present_game_title',
     descriptionKey: 'achievement_no_present_game_desc',
     progress: ({ game }) => {
@@ -397,6 +425,7 @@ export const ACHIEVEMENTS: AchievementDef[] = [
     category: 'performance',
     modes: ['daily'],
     difficulty: 6,
+    metadata: REWARD_METADATA.v1_7_0,
     titleKey: 'achievement_no_correct_game_title',
     descriptionKey: 'achievement_no_correct_game_desc',
     progress: ({ game }) => {

--- a/src/lib/cosmetics.ts
+++ b/src/lib/cosmetics.ts
@@ -1,3 +1,5 @@
+import { REWARD_METADATA, RewardMetadata } from './rewardMetadata'
+
 // --- Type Definitions ---
 
 export type CosmeticCategory =
@@ -20,6 +22,7 @@ export type CosmeticOption = {
   category: CosmeticCategory
   titleKey: string
   requiresAchievement?: string
+  metadata?: RewardMetadata
 }
 
 type CosmeticState = {
@@ -162,30 +165,35 @@ export const COSMETIC_OPTIONS: CosmeticOption[] = [
     id: 'emoji_default',
     category: 'shareEmoji',
     titleKey: 'cosmetic_emoji_default',
+    metadata: REWARD_METADATA.v1_5_0,
   },
   {
     id: 'emoji_circle',
     category: 'shareEmoji',
     titleKey: 'cosmetic_emoji_circle',
     requiresAchievement: 'play_10',
+    metadata: REWARD_METADATA.v1_5_0,
   },
   {
     id: 'emoji_heart',
     category: 'shareEmoji',
     titleKey: 'cosmetic_emoji_heart',
     requiresAchievement: 'win_in_3',
+    metadata: REWARD_METADATA.v1_5_0,
   },
   {
     id: 'emoji_bibimbap',
     category: 'shareEmoji',
     titleKey: 'cosmetic_emoji_bibimbap',
     requiresAchievement: 'bibimbap_balance',
+    metadata: REWARD_METADATA.v1_6_0,
   },
   {
     id: 'emoji_yogurt',
     category: 'shareEmoji',
     titleKey: 'cosmetic_emoji_yogurt',
     requiresAchievement: 'yogurt_recipe',
+    metadata: REWARD_METADATA.v1_6_0,
   },
 
   // Share Badge
@@ -193,78 +201,91 @@ export const COSMETIC_OPTIONS: CosmeticOption[] = [
     id: 'badge_chain',
     category: 'shareBadge',
     titleKey: 'cosmetic_badge_chain',
+    metadata: REWARD_METADATA.v1_6_0,
   },
   {
     id: 'badge_fire',
     category: 'shareBadge',
     titleKey: 'cosmetic_badge_fire',
     requiresAchievement: 'streak_14',
+    metadata: REWARD_METADATA.v1_6_0,
   },
   {
     id: 'badge_calendar',
     category: 'shareBadge',
     titleKey: 'cosmetic_badge_calendar',
     requiresAchievement: 'monthly_attendance',
+    metadata: REWARD_METADATA.v1_6_0,
   },
   {
     id: 'badge_lizard',
     category: 'shareBadge',
     titleKey: 'cosmetic_badge_lizard',
     requiresAchievement: 'dead_end_tail',
+    metadata: REWARD_METADATA.v1_6_0,
   },
   {
     id: 'badge_six',
     category: 'shareBadge',
     titleKey: 'cosmetic_badge_six',
     requiresAchievement: 'played_v1_6_0_5',
+    metadata: REWARD_METADATA.v1_6_0,
   },
   {
     id: 'badge_skull',
     category: 'shareBadge',
     titleKey: 'cosmetic_badge_skull',
     requiresAchievement: 'fail_100',
+    metadata: REWARD_METADATA.v1_6_0,
   },
   {
     id: 'badge_star',
     category: 'shareBadge',
     titleKey: 'cosmetic_badge_star',
     requiresAchievement: 'play_150',
+    metadata: REWARD_METADATA.v1_6_0,
   },
   {
     id: 'badge_hundred',
     category: 'shareBadge',
     titleKey: 'cosmetic_badge_hundred',
     requiresAchievement: 'practice_win_100',
+    metadata: REWARD_METADATA.v1_6_0,
   },
   {
     id: 'badge_wrestle',
     category: 'shareBadge',
     titleKey: 'cosmetic_badge_wrestle',
     requiresAchievement: 'custom_win_10',
+    metadata: REWARD_METADATA.v1_6_0,
   },
   {
     id: 'badge_apple',
     category: 'shareBadge',
     titleKey: 'cosmetic_badge_apple',
     requiresAchievement: 'no_present_game',
+    metadata: REWARD_METADATA.v1_7_0,
   },
   {
     id: 'badge_grape',
     category: 'shareBadge',
     titleKey: 'cosmetic_badge_grape',
     requiresAchievement: 'no_correct_game',
+    metadata: REWARD_METADATA.v1_7_0,
   },
   {
     id: 'badge_milk',
     category: 'shareBadge',
     titleKey: 'cosmetic_badge_milk',
     requiresAchievement: 'win_in_6_20',
+    metadata: REWARD_METADATA.v1_7_0,
   },
   {
     id: 'badge_azure',
     category: 'shareBadge',
     titleKey: 'cosmetic_badge_azure',
     requiresAchievement: 'played_v1_7_0_5',
+    metadata: REWARD_METADATA.v1_7_0,
   },
 
   // Cell Font
@@ -272,18 +293,21 @@ export const COSMETIC_OPTIONS: CosmeticOption[] = [
     id: 'font_default',
     category: 'cellFont',
     titleKey: 'cosmetic_font_default',
+    metadata: REWARD_METADATA.v1_5_0,
   },
   {
     id: 'font_pixel',
     category: 'cellFont',
     titleKey: 'cosmetic_font_pixel',
     requiresAchievement: 'win_in_4',
+    metadata: REWARD_METADATA.v1_5_0,
   },
   {
     id: 'font_marker',
     category: 'cellFont',
     titleKey: 'cosmetic_font_marker',
     requiresAchievement: 'play_50',
+    metadata: REWARD_METADATA.v1_5_0,
   },
 
   // Cell Color
@@ -291,18 +315,21 @@ export const COSMETIC_OPTIONS: CosmeticOption[] = [
     id: 'color_default',
     category: 'cellColor',
     titleKey: 'cosmetic_color_default',
+    metadata: REWARD_METADATA.v1_5_0,
   },
   {
     id: 'color_gold',
     category: 'cellColor',
     titleKey: 'cosmetic_color_gold',
     requiresAchievement: 'win_in_2',
+    metadata: REWARD_METADATA.v1_5_0,
   },
   {
     id: 'color_black',
     category: 'cellColor',
     titleKey: 'cosmetic_color_black',
     requiresAchievement: 'win_in_5',
+    metadata: REWARD_METADATA.v1_5_0,
   },
 
   // Chain Style
@@ -310,18 +337,21 @@ export const COSMETIC_OPTIONS: CosmeticOption[] = [
     id: 'chain_default',
     category: 'chainStyle',
     titleKey: 'cosmetic_chain_default',
+    metadata: REWARD_METADATA.v1_5_0,
   },
   {
     id: 'chain_dashed',
     category: 'chainStyle',
     titleKey: 'cosmetic_chain_dashed',
     requiresAchievement: 'streak_3',
+    metadata: REWARD_METADATA.v1_5_0,
   },
   {
     id: 'chain_thick',
     category: 'chainStyle',
     titleKey: 'cosmetic_chain_thick',
     requiresAchievement: 'streak_7',
+    metadata: REWARD_METADATA.v1_5_0,
   },
 
   // Chain Color
@@ -329,24 +359,28 @@ export const COSMETIC_OPTIONS: CosmeticOption[] = [
     id: 'chaincolor_black',
     category: 'chainColor',
     titleKey: 'cosmetic_chaincolor_black',
+    metadata: REWARD_METADATA.v1_5_0,
   },
   {
     id: 'chaincolor_silver',
     category: 'chainColor',
     titleKey: 'cosmetic_chaincolor_silver',
     requiresAchievement: 'play_100',
+    metadata: REWARD_METADATA.v1_5_0,
   },
   {
     id: 'chaincolor_gold',
     category: 'chainColor',
     titleKey: 'cosmetic_chaincolor_gold',
     requiresAchievement: 'win_in_1',
+    metadata: REWARD_METADATA.v1_5_0,
   },
   {
     id: 'chaincolor_azure',
     category: 'chainColor',
     titleKey: 'cosmetic_chaincolor_azure',
     requiresAchievement: 'streak_5',
+    metadata: REWARD_METADATA.v1_7_0,
   },
 
   // Alert Message
@@ -354,12 +388,14 @@ export const COSMETIC_OPTIONS: CosmeticOption[] = [
     id: 'msg_classic',
     category: 'endMessage',
     titleKey: 'cosmetic_msg_classic',
+    metadata: REWARD_METADATA.v1_5_0,
   },
   {
     id: 'msg_phrase',
     category: 'endMessage',
     titleKey: 'cosmetic_msg_phrase',
     requiresAchievement: 'win_in_6',
+    metadata: REWARD_METADATA.v1_5_0,
   },
   // {
   //   id: 'msg_chill',
@@ -384,6 +420,7 @@ export const COSMETIC_OPTIONS: CosmeticOption[] = [
     category: 'endMessage',
     titleKey: 'cosmetic_msg_emoji',
     requiresAchievement: 'streak_30',
+    metadata: REWARD_METADATA.v1_5_0,
   },
 ]
 

--- a/src/lib/patchNotes.test.ts
+++ b/src/lib/patchNotes.test.ts
@@ -1,0 +1,31 @@
+import {
+  PATCH_NOTES,
+  getCurrentPatchNotes,
+  getPatchNoteVersions,
+} from './patchNotes'
+import { RELEASE_METADATA } from './releaseMetadata'
+
+describe('patch notes metadata', () => {
+  it('keeps release dates in release metadata', () => {
+    for (const patchNote of PATCH_NOTES) {
+      expect(RELEASE_METADATA[patchNote.version]?.releasedAt).toBeTruthy()
+    }
+  })
+
+  it('hydrates patch notes with release metadata', () => {
+    expect(getPatchNoteVersions()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          version: '1.6.0',
+          releasedAt: '2026-05-10',
+        }),
+      ])
+    )
+  })
+
+  it('falls back to the latest patch notes for unknown current versions', () => {
+    expect(getCurrentPatchNotes('9.9.9')).toMatchObject({
+      version: PATCH_NOTES[0].version,
+    })
+  })
+})

--- a/src/lib/patchNotes.ts
+++ b/src/lib/patchNotes.ts
@@ -1,0 +1,163 @@
+import { RELEASE_METADATA } from './releaseMetadata'
+
+export type PatchNoteFeature = {
+  icon: string
+  titleKey: string
+  descKey: string
+  sub?: readonly PatchNoteFeature[]
+}
+
+export type PatchNote = {
+  version: string
+  features: readonly PatchNoteFeature[]
+}
+
+export type PatchNoteVersion = PatchNote & {
+  releasedAt: string
+}
+
+export const PATCH_NOTES: readonly PatchNote[] = [
+  {
+    version: '1.6.0',
+    features: [
+      {
+        icon: '📝',
+        titleKey: 'patchNote_updateHistory_title',
+        descKey: 'patchNote_updateHistory_desc',
+      },
+      {
+        icon: '🏷️',
+        titleKey: 'patchNote_shareBadges_title',
+        descKey: 'patchNote_shareBadges_desc',
+      },
+      {
+        icon: '🧩',
+        titleKey: 'patchNote_newAchievements_title',
+        descKey: 'patchNote_newAchievements_desc',
+      },
+      {
+        icon: '🍚',
+        titleKey: 'patchNote_recipeEmoji_title',
+        descKey: 'patchNote_recipeEmoji_desc',
+      },
+    ],
+  },
+  {
+    version: '1.5.0',
+    features: [
+      {
+        icon: '🏆',
+        titleKey: 'patchNote_achievements_title',
+        descKey: 'patchNote_achievements_desc',
+      },
+      {
+        icon: '🎨',
+        titleKey: 'patchNote_cosmetics_title',
+        descKey: 'patchNote_cosmetics_desc',
+      },
+      {
+        icon: '🇩🇪',
+        titleKey: 'patchNote_german_title',
+        descKey: 'patchNote_german_desc',
+      },
+      {
+        icon: '🔧',
+        titleKey: 'patchNote_uiFixes_title',
+        descKey: 'patchNote_uiFixes_desc',
+      },
+    ],
+  },
+  {
+    version: '1.4.0',
+    features: [
+      {
+        icon: '🕛',
+        titleKey: 'patchNote_localTimezone_title',
+        descKey: 'patchNote_localTimezone_desc',
+      },
+      {
+        icon: '🧭',
+        titleKey: 'patchNote_uiRefactor_title',
+        descKey: 'patchNote_uiRefactor_desc',
+      },
+      {
+        icon: '💖',
+        titleKey: 'patchNote_sponsors_title',
+        descKey: 'patchNote_sponsors_desc',
+      },
+    ],
+  },
+  {
+    version: '1.3.0',
+    features: [
+      {
+        icon: '📅',
+        titleKey: 'patchNote_calendar_title',
+        descKey: 'patchNote_calendar_desc',
+      },
+    ],
+  },
+  {
+    version: '1.2.0',
+    features: [
+      {
+        icon: '🧩',
+        titleKey: 'patchNote_customPuzzle_title',
+        descKey: 'patchNote_customPuzzle_desc',
+      },
+      {
+        icon: '💝',
+        titleKey: 'patchNote_donations_title',
+        descKey: 'patchNote_donations_desc',
+        sub: [
+          {
+            icon: '💛',
+            titleKey: 'patchNote_kakaopay_title',
+            descKey: 'patchNote_kakaopay_desc',
+          },
+          {
+            icon: '💙',
+            titleKey: 'patchNote_tosspay_title',
+            descKey: 'patchNote_tosspay_desc',
+          },
+        ],
+      },
+      {
+        icon: 'ℹ️',
+        titleKey: 'patchNote_infoModal_title',
+        descKey: 'patchNote_infoModal_desc',
+      },
+      {
+        icon: '✨',
+        titleKey: 'patchNote_ui_title',
+        descKey: 'patchNote_ui_desc',
+        sub: [
+          {
+            icon: '🏷️',
+            titleKey: 'patchNote_subtitle_title',
+            descKey: 'patchNote_subtitle_desc',
+          },
+          {
+            icon: '🏳️',
+            titleKey: 'patchNote_flags_title',
+            descKey: 'patchNote_flags_desc',
+          },
+        ],
+      },
+    ],
+  },
+]
+
+export const getPatchNoteVersions = (): PatchNoteVersion[] =>
+  PATCH_NOTES.map((patchNote) => ({
+    ...patchNote,
+    releasedAt: RELEASE_METADATA[patchNote.version]?.releasedAt ?? '',
+  }))
+
+export const getCurrentPatchNotes = (version: string): PatchNoteVersion => {
+  const patchNoteVersions = getPatchNoteVersions()
+  return (
+    patchNoteVersions.find((patchNote) => patchNote.version === version) ??
+    patchNoteVersions[0]
+  )
+}

--- a/src/lib/releaseMetadata.ts
+++ b/src/lib/releaseMetadata.ts
@@ -1,0 +1,54 @@
+export type ReleaseEventMetadata = {
+  id: string
+  mode: string
+  ruleTags: readonly string[]
+}
+
+export type ReleaseMetadata = {
+  version: string
+  theme?: string
+  events?: readonly ReleaseEventMetadata[]
+}
+
+export const RELEASE_METADATA: Record<string, ReleaseMetadata> = {
+  '1.5.0': {
+    version: '1.5.0',
+    theme: 'core',
+  },
+  '1.6.0': {
+    version: '1.6.0',
+    theme: 'recipe',
+  },
+  '1.7.0': {
+    version: '1.7.0',
+    theme: 'summer',
+    events: [
+      {
+        id: 'hardcore',
+        mode: 'hardcore',
+        ruleTags: [
+          'forced-word',
+          'hidden-letters',
+          'hidden-keyboard-status',
+          'time-limit',
+          'limited-enter',
+        ],
+      },
+    ],
+  },
+  '1.8.0': {
+    version: '1.8.0',
+    theme: 'horror',
+    events: [
+      {
+        id: 'ai',
+        mode: 'ai',
+        ruleTags: [
+          'alternating-turns',
+          'themed-prefer-word-list',
+          'theme-cosmetic-overrides',
+        ],
+      },
+    ],
+  },
+}

--- a/src/lib/releaseMetadata.ts
+++ b/src/lib/releaseMetadata.ts
@@ -36,34 +36,6 @@ export const RELEASE_METADATA: Record<string, ReleaseMetadata> = {
   },
   '1.7.0': {
     version: '1.7.0',
-    theme: 'summer',
-    events: [
-      {
-        id: 'hardcore',
-        mode: 'hardcore',
-        ruleTags: [
-          'forced-word',
-          'hidden-letters',
-          'hidden-keyboard-status',
-          'time-limit',
-          'limited-enter',
-        ],
-      },
-    ],
-  },
-  '1.8.0': {
-    version: '1.8.0',
-    theme: 'horror',
-    events: [
-      {
-        id: 'ai',
-        mode: 'ai',
-        ruleTags: [
-          'alternating-turns',
-          'themed-prefer-word-list',
-          'theme-cosmetic-overrides',
-        ],
-      },
-    ],
+    theme: 'summer garden',
   },
 }

--- a/src/lib/releaseMetadata.ts
+++ b/src/lib/releaseMetadata.ts
@@ -6,17 +6,32 @@ export type ReleaseEventMetadata = {
 
 export type ReleaseMetadata = {
   version: string
+  releasedAt?: string
   theme?: string
   events?: readonly ReleaseEventMetadata[]
 }
 
 export const RELEASE_METADATA: Record<string, ReleaseMetadata> = {
+  '1.2.0': {
+    version: '1.2.0',
+    releasedAt: '2026-02-28',
+  },
+  '1.3.0': {
+    version: '1.3.0',
+    releasedAt: '2026-03-07',
+  },
+  '1.4.0': {
+    version: '1.4.0',
+    releasedAt: '2026-03-12',
+  },
   '1.5.0': {
     version: '1.5.0',
+    releasedAt: '2026-04-20',
     theme: 'core',
   },
   '1.6.0': {
     version: '1.6.0',
+    releasedAt: '2026-05-10',
     theme: 'recipe',
   },
   '1.7.0': {

--- a/src/lib/releaseMetadata.ts
+++ b/src/lib/releaseMetadata.ts
@@ -27,7 +27,6 @@ export const RELEASE_METADATA: Record<string, ReleaseMetadata> = {
   '1.5.0': {
     version: '1.5.0',
     releasedAt: '2026-04-20',
-    theme: 'core',
   },
   '1.6.0': {
     version: '1.6.0',

--- a/src/lib/rewardMetadata.test.ts
+++ b/src/lib/rewardMetadata.test.ts
@@ -1,7 +1,10 @@
 import { ACHIEVEMENTS } from './achievements'
 import { COSMETIC_OPTIONS } from './cosmetics'
 import { RELEASE_METADATA } from './releaseMetadata'
-import { filterRewardsByMetadata } from './rewardMetadata'
+import {
+  filterRewardsByMetadata,
+  getRewardMetadataLabel,
+} from './rewardMetadata'
 
 describe('reward metadata', () => {
   it('tracks introduced version for every achievement and cosmetic option', () => {
@@ -51,5 +54,14 @@ describe('reward metadata', () => {
     expect(RELEASE_METADATA['1.7.0']).toMatchObject({
       theme: 'summer garden',
     })
+  })
+
+  it('formats reward metadata labels from release metadata', () => {
+    expect(getRewardMetadataLabel({ introducedInVersion: '1.7.0' })).toBe(
+      'v1.7.0 (summer garden)'
+    )
+    expect(getRewardMetadataLabel({ introducedInVersion: '1.3.0' })).toBe(
+      'v1.3.0'
+    )
   })
 })

--- a/src/lib/rewardMetadata.test.ts
+++ b/src/lib/rewardMetadata.test.ts
@@ -1,0 +1,60 @@
+import { ACHIEVEMENTS } from './achievements'
+import { COSMETIC_OPTIONS } from './cosmetics'
+import { RELEASE_METADATA } from './releaseMetadata'
+import { filterRewardsByMetadata } from './rewardMetadata'
+
+describe('reward metadata', () => {
+  it('tracks introduced version for every achievement and cosmetic option', () => {
+    expect(ACHIEVEMENTS.every((a) => a.metadata?.introducedInVersion)).toBe(
+      true
+    )
+    expect(
+      COSMETIC_OPTIONS.every((option) => option.metadata?.introducedInVersion)
+    ).toBe(true)
+  })
+
+  it('filters v1.7.0 achievement metadata', () => {
+    const achievementIds = filterRewardsByMetadata(ACHIEVEMENTS, {
+      introducedInVersion: '1.7.0',
+    })
+      .map((achievement) => achievement.id)
+      .sort()
+
+    expect(achievementIds).toEqual(
+      [
+        'no_correct_game',
+        'no_present_game',
+        'played_v1_7_0_5',
+        'streak_5',
+        'win_in_6_20',
+      ].sort()
+    )
+  })
+
+  it('filters v1.7.0 cosmetic metadata', () => {
+    const cosmeticIds = filterRewardsByMetadata(COSMETIC_OPTIONS, {
+      introducedInVersion: '1.7.0',
+    }).map((option) => option.id)
+
+    expect(cosmeticIds.sort()).toEqual(
+      [
+        'badge_apple',
+        'badge_azure',
+        'badge_grape',
+        'badge_milk',
+        'chaincolor_azure',
+      ].sort()
+    )
+  })
+
+  it('keeps release-level theme and event metadata separate from rewards', () => {
+    expect(RELEASE_METADATA['1.7.0']).toMatchObject({
+      theme: 'summer',
+      events: [expect.objectContaining({ id: 'hardcore' })],
+    })
+    expect(RELEASE_METADATA['1.8.0']).toMatchObject({
+      theme: 'horror',
+      events: [expect.objectContaining({ id: 'ai' })],
+    })
+  })
+})

--- a/src/lib/rewardMetadata.test.ts
+++ b/src/lib/rewardMetadata.test.ts
@@ -49,12 +49,7 @@ describe('reward metadata', () => {
 
   it('keeps release-level theme and event metadata separate from rewards', () => {
     expect(RELEASE_METADATA['1.7.0']).toMatchObject({
-      theme: 'summer',
-      events: [expect.objectContaining({ id: 'hardcore' })],
-    })
-    expect(RELEASE_METADATA['1.8.0']).toMatchObject({
-      theme: 'horror',
-      events: [expect.objectContaining({ id: 'ai' })],
+      theme: 'summer garden',
     })
   })
 })

--- a/src/lib/rewardMetadata.ts
+++ b/src/lib/rewardMetadata.ts
@@ -1,0 +1,44 @@
+export type RewardMetadata = {
+  introducedInVersion: string
+}
+
+export type RewardMetadataFilter = {
+  introducedInVersion?: string
+}
+
+type RewardMetadataCarrier = {
+  metadata?: RewardMetadata
+}
+
+export const matchesRewardMetadata = (
+  metadata: RewardMetadata | undefined,
+  filter: RewardMetadataFilter
+): boolean => {
+  if (!metadata) {
+    return false
+  }
+
+  if (
+    filter.introducedInVersion &&
+    metadata.introducedInVersion !== filter.introducedInVersion
+  ) {
+    return false
+  }
+
+  return true
+}
+
+export const filterRewardsByMetadata = <T extends RewardMetadataCarrier>(
+  rewards: readonly T[],
+  filter: RewardMetadataFilter
+): T[] =>
+  rewards.filter((reward) => matchesRewardMetadata(reward.metadata, filter))
+
+export const REWARD_METADATA: Record<
+  'v1_5_0' | 'v1_6_0' | 'v1_7_0',
+  RewardMetadata
+> = {
+  v1_5_0: { introducedInVersion: '1.5.0' },
+  v1_6_0: { introducedInVersion: '1.6.0' },
+  v1_7_0: { introducedInVersion: '1.7.0' },
+}

--- a/src/lib/rewardMetadata.ts
+++ b/src/lib/rewardMetadata.ts
@@ -1,3 +1,5 @@
+import { RELEASE_METADATA } from './releaseMetadata'
+
 export type RewardMetadata = {
   introducedInVersion: string
 }
@@ -33,6 +35,18 @@ export const filterRewardsByMetadata = <T extends RewardMetadataCarrier>(
   filter: RewardMetadataFilter
 ): T[] =>
   rewards.filter((reward) => matchesRewardMetadata(reward.metadata, filter))
+
+export const getRewardMetadataLabel = (
+  metadata: RewardMetadata | undefined
+): string => {
+  if (!metadata) {
+    return ''
+  }
+
+  const version = metadata.introducedInVersion
+  const theme = RELEASE_METADATA[version]?.theme
+  return theme ? `v${version} (${theme})` : `v${version}`
+}
 
 export const REWARD_METADATA: Record<
   'v1_5_0' | 'v1_6_0' | 'v1_7_0',


### PR DESCRIPTION
## Summary
- Add release/reward metadata models and attach introduced-version metadata to achievements and cosmetics.
- Centralize patch note structure and release dates so patch history can share release metadata.
- Surface reward release labels in Achievements and Settings for quick review.

## Related
- Closes #164 as the reward metadata portion of this broader release metadata cleanup.

## Test plan
- npm test -- --watchAll=false achievements rewardMetadata
- npm test -- --watchAll=false patchNotes rewardMetadata
- PUBLIC_URL=/ npm run build