### PR TITLE
feat: add rewards modal

### DIFF
--- a/e2e/achievements-cosmetics.spec.ts
+++ b/e2e/achievements-cosmetics.spec.ts
@@ -11,22 +11,19 @@ test.describe('Achievements & Cosmetics', () => {
     await waitForGameReady(gamePage)
   })
 
-  test('achievements tab shows in stats modal', async ({ gamePage }) => {
-    // Open stats modal (icon index 1 in daily mode)
-    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(1).click()
+  test('achievements tab shows in rewards modal', async ({ gamePage }) => {
+    // Open rewards modal (icon index 2 in daily mode)
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
     await expect(
-      gamePage.getByRole('heading', { name: 'Records' })
+      gamePage.getByRole('heading', { name: 'Rewards' })
     ).toBeVisible()
-
-    // Click Achievements tab
-    await gamePage.locator('button', { hasText: 'Achievements' }).click()
 
     // Should show achievement cards
     await expect(gamePage.locator('text=Getting Started')).toBeVisible()
     await expect(
       gamePage.locator('[data-achievement-id="play_10"]')
     ).toContainText('Daily')
-    await expect(gamePage.locator('text=Play 10 games')).toBeVisible()
+    await expect(gamePage.locator('text=Complete 10 games')).toBeVisible()
     await screenshot(gamePage, '01-achievements-tab')
 
     // Progress bar container should be visible
@@ -53,9 +50,8 @@ test.describe('Achievements & Cosmetics', () => {
     await gamePage.reload()
     await waitForGameReady(gamePage)
 
-    // Open stats → achievements
-    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(1).click()
-    await gamePage.locator('button', { hasText: 'Achievements' }).click()
+    // Open rewards
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
 
     // Getting Started should have green border (unlocked)
     const card = gamePage.locator('[data-achievement-id="play_10"]')
@@ -90,9 +86,8 @@ test.describe('Achievements & Cosmetics', () => {
     expect(state.unlocked.play_10).toBeTruthy()
     expect(state.unlocked.streak_3).toBeTruthy()
 
-    // Open achievements tab to verify visually
-    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(1).click()
-    await gamePage.locator('button', { hasText: 'Achievements' }).click()
+    // Open rewards to verify visually
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
 
     const play10 = gamePage.locator('[data-achievement-id="play_10"]')
     await expect(play10).toHaveClass(/border-green-400/)
@@ -101,17 +96,18 @@ test.describe('Achievements & Cosmetics', () => {
     await screenshot(gamePage, '01-retro-unlock')
   })
 
-  test('cosmetics section in settings modal', async ({ gamePage }) => {
-    // Open settings (icon index 2 in daily mode)
+  test('cosmetics section in rewards modal', async ({ gamePage }) => {
+    // Open rewards (icon index 2 in daily mode)
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
-    await expect(gamePage.locator('text=Settings')).toBeVisible()
+    await expect(gamePage.locator('text=Rewards')).toBeVisible()
+    await gamePage.locator('button', { hasText: 'Cosmetics' }).click()
 
     // Sample grid should be visible
     await expect(gamePage.locator('text=Share Emoji')).toBeVisible()
     await expect(gamePage.locator('text=Share Badge')).toBeVisible()
     await expect(gamePage.locator('text=Cell Font')).toBeVisible()
     await expect(gamePage.locator('text=Chain Style')).toBeVisible()
-    await screenshot(gamePage, '01-settings-cosmetics')
+    await screenshot(gamePage, '01-rewards-cosmetics')
   })
 
   test('share emoji cosmetic changes share output', async ({ gamePage }) => {
@@ -134,8 +130,9 @@ test.describe('Achievements & Cosmetics', () => {
     await gamePage.reload()
     await waitForGameReady(gamePage)
 
-    // Open settings to verify sample view uses circle emoji
+    // Open rewards to verify sample view uses circle emoji
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
+    await gamePage.locator('button', { hasText: 'Cosmetics' }).click()
 
     // Share preview should contain circle emoji
     const sharePreview = gamePage.locator('pre')
@@ -158,8 +155,9 @@ test.describe('Achievements & Cosmetics', () => {
     await gamePage.reload()
     await waitForGameReady(gamePage)
 
-    // Open settings
+    // Open rewards
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
+    await gamePage.locator('button', { hasText: 'Cosmetics' }).click()
 
     // Click Share Emoji picker button (first cosmetic picker)
     await gamePage.locator('button:has-text("Square")').click()
@@ -180,8 +178,9 @@ test.describe('Achievements & Cosmetics', () => {
   })
 
   test('locked cosmetic shows lock icon', async ({ gamePage }) => {
-    // Open settings
+    // Open rewards
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
+    await gamePage.locator('button', { hasText: 'Cosmetics' }).click()
 
     // Click Share Emoji picker
     await gamePage.locator('button:has-text("Square")').click()

--- a/e2e/calendar.spec.ts
+++ b/e2e/calendar.spec.ts
@@ -41,9 +41,9 @@ async function injectHistory(
 }
 
 // Daily mode header icons:
-// 0:Info  1:Stats  2:Settings  3:Donate
+// 0:Info  1:Stats  2:Rewards  3:Settings  4:Donate
 const STATS_ICON = 1
-const SETTINGS_ICON = 2
+const SETTINGS_ICON = 3
 
 /** Open the Stats modal and switch to the Calendar tab */
 async function openCalendarTab(page: Page) {
@@ -212,13 +212,13 @@ test.describe('Calendar', () => {
   test('stats icon visible in daily, hidden in practice (no calendar tab)', async ({
     gamePage,
   }) => {
-    // Daily: 4 icons (info, stats, settings, donate)
-    await expect(gamePage.locator('svg.h-6.w-6.cursor-pointer')).toHaveCount(4)
+    // Daily: 5 icons (info, stats, rewards, settings, donate)
+    await expect(gamePage.locator('svg.h-6.w-6.cursor-pointer')).toHaveCount(5)
 
-    // Practice: 3 icons (no stats)
+    // Practice: 4 icons (no stats)
     await gamePage.goto('/#/practice')
     await waitForGameReady(gamePage)
-    await expect(gamePage.locator('svg.h-6.w-6.cursor-pointer')).toHaveCount(3)
+    await expect(gamePage.locator('svg.h-6.w-6.cursor-pointer')).toHaveCount(4)
     await screenshot(gamePage, '01-no-stats-in-practice')
   })
 })

--- a/e2e/modals.spec.ts
+++ b/e2e/modals.spec.ts
@@ -112,7 +112,7 @@ test.describe('Modals', () => {
       .locator('button', { hasText: 'Enter' })
       .waitFor({ state: 'visible' })
 
-    // Create page icons: info(0), settings(1), donate(2)
+    // Create page icons: info(0), rewards(1), settings(2), donate(3)
     await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(0).click()
     await expect(
       gamePage.getByRole('heading', { name: 'Information' })
@@ -158,13 +158,12 @@ test.describe('Modals', () => {
   test('dead end achievement help opens the chain rule explanation', async ({
     gamePage,
   }) => {
-    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(1).click()
-    await gamePage.locator('button', { hasText: 'Achievements' }).click()
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
 
     await gamePage.locator('button', { hasText: 'Dead End rule' }).click()
 
     await expect(
-      gamePage.getByRole('heading', { name: 'Records' })
+      gamePage.getByRole('heading', { name: 'Rewards' })
     ).not.toBeVisible({ timeout: 1000 })
     await expect(
       gamePage.getByRole('heading', { name: 'Information' })
@@ -177,8 +176,8 @@ test.describe('Modals', () => {
   })
 
   test('settings modal with uppercase toggle', async ({ gamePage }) => {
-    // Click settings icon (CogIcon) — 3rd icon (0:info, 1:stats, 2:settings)
-    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
+    // Click settings icon (CogIcon) — 4th icon (0:info, 1:stats, 2:rewards, 3:settings)
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(3).click()
 
     await expect(gamePage.locator('text=Settings')).toBeVisible()
     await expect(gamePage.locator('text=Display in Uppercase')).toBeVisible()
@@ -197,7 +196,7 @@ test.describe('Modals', () => {
     await screenshot(gamePage, '03-uppercase-applied-to-page')
 
     // Reopen settings and toggle off
-    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(3).click()
     await gamePage.locator('button[role="switch"]').first().click()
     await screenshot(gamePage, '04-uppercase-toggle-off')
     await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
@@ -210,8 +209,8 @@ test.describe('Modals', () => {
   test('uppercase setting persists across page navigation', async ({
     gamePage,
   }) => {
-    // Daily: enable uppercase via settings (settings = 3rd icon)
-    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
+    // Daily: enable uppercase via settings (settings = 4th icon)
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(3).click()
     await gamePage.locator('button[role="switch"]').first().click()
     await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
     await expect(gamePage.locator('div.uppercase').first()).toBeVisible()
@@ -237,8 +236,8 @@ test.describe('Modals', () => {
     await expect(gamePage.locator('div.uppercase').first()).toBeVisible()
     await screenshot(gamePage, '04-create-uppercase-persisted')
 
-    // Toggle off on Create page (settings = 2nd icon: info, settings)
-    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(1).click()
+    // Toggle off on Create page (settings = 3rd icon: info, rewards, settings)
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
     await gamePage.locator('button[role="switch"]').first().click()
     await gamePage.locator('svg.h-6.w-6.cursor-pointer >> nth=-1').click()
     await expect(gamePage.locator('div.uppercase').first()).not.toBeVisible()
@@ -258,8 +257,8 @@ test.describe('Modals', () => {
   })
 
   test('donate modal opens and closes', async ({ gamePage }) => {
-    // Click donate icon (CurrencyDollarIcon) — 4th icon (0:info, 1:stats, 2:settings, 3:donate)
-    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(3).click()
+    // Click donate icon (CurrencyDollarIcon) — 5th icon (0:info, 1:stats, 2:rewards, 3:settings, 4:donate)
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(4).click()
 
     await expect(gamePage.locator('h3:has-text("Donate")')).toBeVisible()
 
@@ -300,8 +299,8 @@ test.describe('Modals', () => {
   })
 
   test('language selector in settings modal', async ({ gamePage }) => {
-    // Open settings (0:info, 1:stats, 2:settings)
-    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
+    // Open settings (0:info, 1:stats, 2:rewards, 3:settings)
+    await gamePage.locator('svg.h-6.w-6.cursor-pointer').nth(3).click()
     await expect(gamePage.locator('text=Settings')).toBeVisible()
 
     // Language picker button should be visible with English

--- a/e2e/navigation.spec.ts
+++ b/e2e/navigation.spec.ts
@@ -1,4 +1,10 @@
-import { test, expect, customPuzzlePath, waitForGameReady, screenshot } from './fixtures/game.fixture'
+import {
+  test,
+  expect,
+  customPuzzlePath,
+  waitForGameReady,
+  screenshot,
+} from './fixtures/game.fixture'
 
 test.describe('Navigation', () => {
   test('daily page renders with date subtitle', async ({ gamePage }) => {
@@ -20,7 +26,9 @@ test.describe('Navigation', () => {
     await screenshot(gamePage, '01-practice-page')
   })
 
-  test('navigate from daily to practice via bottom button', async ({ gamePage }) => {
+  test('navigate from daily to practice via bottom button', async ({
+    gamePage,
+  }) => {
     await gamePage.goto('/')
     await waitForGameReady(gamePage)
     await screenshot(gamePage, '01-daily-before-navigate')
@@ -31,7 +39,9 @@ test.describe('Navigation', () => {
     await screenshot(gamePage, '02-practice-after-navigate')
   })
 
-  test('navigate from practice to daily via bottom button', async ({ gamePage }) => {
+  test('navigate from practice to daily via bottom button', async ({
+    gamePage,
+  }) => {
     await gamePage.goto('/#/practice')
     await waitForGameReady(gamePage)
     await screenshot(gamePage, '01-practice-before-navigate')
@@ -45,12 +55,18 @@ test.describe('Navigation', () => {
     await gamePage.goto('/#/create')
     await waitForGameReady(gamePage)
 
-    await expect(gamePage.locator('p.text-green-500', { hasText: 'Create' })).toBeVisible()
-    await expect(gamePage.locator('input[placeholder="Enter your name"]')).toBeVisible()
+    await expect(
+      gamePage.locator('p.text-green-500', { hasText: 'Create' })
+    ).toBeVisible()
+    await expect(
+      gamePage.locator('input[placeholder="Enter your name"]')
+    ).toBeVisible()
     await screenshot(gamePage, '01-create-puzzle-page')
   })
 
-  test('navigate from daily to create via bottom button', async ({ gamePage }) => {
+  test('navigate from daily to create via bottom button', async ({
+    gamePage,
+  }) => {
     await gamePage.goto('/')
     await waitForGameReady(gamePage)
 
@@ -77,7 +93,9 @@ test.describe('Navigation', () => {
     await screenshot(gamePage, '01-redirected-to-daily')
   })
 
-  test('stats icon visible on daily, hidden on practice', async ({ gamePage }) => {
+  test('stats icon visible on daily, hidden on practice', async ({
+    gamePage,
+  }) => {
     // Daily: stats icon visible
     await gamePage.goto('/')
     await waitForGameReady(gamePage)
@@ -92,9 +110,9 @@ test.describe('Navigation', () => {
     // Count cursor-pointer SVG icons in header
     const headerIcons = gamePage.locator('.flex.w-80 svg.cursor-pointer')
     const count = await headerIcons.count()
-    // Daily has: info, stats, settings, donate (4)
-    // Practice has: info, settings, donate (3)
-    expect(count).toBeLessThan(4)
+    // Daily has: info, stats, rewards, settings, donate (5)
+    // Practice has: info, rewards, settings, donate (4)
+    expect(count).toBe(4)
     await screenshot(gamePage, '02-practice-without-stats-icon')
   })
 })

--- a/e2e/share-exclude-url.spec.ts
+++ b/e2e/share-exclude-url.spec.ts
@@ -14,7 +14,7 @@ test.describe('Share — Exclude URL setting', () => {
     'Clipboard API requires Chromium'
   )
 
-  const SETTINGS_ICON_DAILY = 2 // 0:info, 1:stats, 2:settings
+  const SETTINGS_ICON_DAILY = 3 // 0:info, 1:stats, 2:rewards, 3:settings
 
   /** Grant clipboard permissions and navigate to a custom puzzle */
   async function setupCustomGame(gamePage: import('@playwright/test').Page) {
@@ -46,8 +46,8 @@ test.describe('Share — Exclude URL setting', () => {
 
   /** Toggle the Exclude URL setting on/off */
   async function toggleExcludeUrl(gamePage: import('@playwright/test').Page) {
-    // Custom mode: 0:info, 1:settings, 2:donate
-    const settingsIndex = 1
+    // Custom mode: 0:info, 1:rewards, 2:settings, 3:donate
+    const settingsIndex = 2
     await gamePage
       .locator('svg.h-6.w-6.cursor-pointer')
       .nth(settingsIndex)

--- a/scripts/generate-readme-screenshots.spec.ts
+++ b/scripts/generate-readme-screenshots.spec.ts
@@ -240,8 +240,8 @@ test('settings with language selector (Korean)', async ({ page }) => {
   await page.goto('/')
   await page.locator('button:text-is("q")').waitFor({ state: 'visible' })
 
-  // Open Settings modal (icon index 2)
-  await page.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
+  // Open Settings modal (icon index 3)
+  await page.locator('svg.h-6.w-6.cursor-pointer').nth(3).click()
   await page.waitForTimeout(500)
   await save(page, 'settings-kor')
 })
@@ -286,8 +286,8 @@ test('settings modal with all toggles', async ({ page }) => {
   await page.goto('/')
   await waitForGameReady(page)
 
-  // Open settings (Daily mode: icon index 2)
-  await page.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
+  // Open settings (Daily mode: icon index 3)
+  await page.locator('svg.h-6.w-6.cursor-pointer').nth(3).click()
   await page.locator('text=Settings').waitFor({ state: 'visible' })
   await page.waitForTimeout(300)
   await save(page, 'settings')
@@ -298,8 +298,8 @@ test('donate modal', async ({ page }) => {
   await page.goto('/')
   await waitForGameReady(page)
 
-  // Click donate icon (Daily mode: icon index 3)
-  await page.locator('svg.h-6.w-6.cursor-pointer').nth(3).click()
+  // Click donate icon (Daily mode: icon index 4)
+  await page.locator('svg.h-6.w-6.cursor-pointer').nth(4).click()
   await page.locator('h3:has-text("Donate")').waitFor({ state: 'visible' })
   await page.waitForTimeout(500)
   await save(page, 'donation')
@@ -393,15 +393,14 @@ test('achievements tab with unlocked and locked', async ({ page }) => {
   await page.goto('/')
   await waitForGameReady(page)
 
-  // Open Stats → Achievements tab
-  await page.locator('svg.h-6.w-6.cursor-pointer').nth(1).click()
-  await page.locator('text=Statistics').waitFor({ state: 'visible' })
-  await page.locator('text=Achievements').click()
+  // Open Rewards → Achievements tab
+  await page.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
+  await page.locator('text=Rewards').waitFor({ state: 'visible' })
   await page.waitForTimeout(500)
   await save(page, 'achievements')
 })
 
-test('settings with cosmetics and sample view', async ({ page }) => {
+test('rewards with cosmetics and sample view', async ({ page }) => {
   await initPage(page)
 
   // Unlock some achievements for cosmetic options
@@ -442,9 +441,10 @@ test('settings with cosmetics and sample view', async ({ page }) => {
   await page.goto('/')
   await waitForGameReady(page)
 
-  // Open settings
+  // Open rewards
   await page.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
-  await page.locator('text=Settings').waitFor({ state: 'visible' })
+  await page.locator('text=Rewards').waitFor({ state: 'visible' })
+  await page.locator('text=Cosmetics').click()
   await page.waitForTimeout(300)
   await save(page, 'settings-cosmetics')
 })
@@ -473,9 +473,10 @@ test('cosmetic picker popup', async ({ page }) => {
   await page.goto('/')
   await waitForGameReady(page)
 
-  // Open settings → click Share Emoji picker
+  // Open rewards → click Share Emoji picker
   await page.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
-  await page.locator('text=Settings').waitFor({ state: 'visible' })
+  await page.locator('text=Rewards').waitFor({ state: 'visible' })
+  await page.locator('text=Cosmetics').click()
   await page.locator('text=Share Emoji').locator('..').locator('button').click()
   await page.waitForTimeout(300)
   await save(page, 'cosmetic-picker')
@@ -502,9 +503,10 @@ test('alert message theme picker', async ({ page }) => {
   await page.goto('/')
   await waitForGameReady(page)
 
-  // Open settings → click Alert Message picker
+  // Open rewards → click Alert Message picker
   await page.locator('svg.h-6.w-6.cursor-pointer').nth(2).click()
-  await page.locator('text=Settings').waitFor({ state: 'visible' })
+  await page.locator('text=Rewards').waitFor({ state: 'visible' })
+  await page.locator('text=Cosmetics').click()
   await page.locator('text=Win Message').locator('..').locator('button').click()
   await page.waitForTimeout(300)
   await save(page, 'alert-message-picker')

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { InformationCircleIcon } from '@heroicons/react/outline'
 import { ClipboardListIcon } from '@heroicons/react/outline'
 import { CogIcon } from '@heroicons/react/outline'
 import { CurrencyDollarIcon } from '@heroicons/react/outline'
+import { SparklesIcon } from '@heroicons/react/outline'
 import { useState, useEffect } from 'react'
 import { Link } from 'react-router-dom'
 import { Alert } from './components/alerts/Alert'
@@ -12,6 +13,7 @@ import { DonateModal } from './components/modals/DonateModal'
 import { PatchNotesModal } from './components/modals/PatchNotesModal'
 import { SettingsModal } from './components/modals/SettingsModal'
 import { StatsModal } from './components/modals/StatsModal'
+import { RewardsModal } from './components/modals/RewardsModal'
 import { Temporal } from 'temporal-polyfill'
 import { isWordInWordList, isWinningWord } from './lib/words'
 import { addStatsForCompletedGame, loadStats } from './lib/stats'
@@ -72,11 +74,9 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
   const [infoInitialTab, setInfoInitialTab] = useState<InfoTab>('mode')
   const [isNotEnoughLetters, setIsNotEnoughLetters] = useState(false)
   const [isStatsModalOpen, setIsStatsModalOpen] = useState(false)
-  const [statsInitialTab, setStatsInitialTab] = useState<
-    'stats' | 'calendar' | 'achievements' | undefined
-  >(undefined)
-  const [scrollToAchievement, setScrollToAchievement] = useState<
-    string | undefined
+  const [isRewardsModalOpen, setIsRewardsModalOpen] = useState(false)
+  const [rewardsInitialTab, setRewardsInitialTab] = useState<
+    'achievements' | 'cosmetics' | undefined
   >(undefined)
 
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false)
@@ -404,6 +404,13 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
             onClick={() => setIsStatsModalOpen(true)}
           />
         )}
+        <SparklesIcon
+          className="h-6 w-6 cursor-pointer"
+          onClick={() => {
+            setRewardsInitialTab('achievements')
+            setIsRewardsModalOpen(true)
+          }}
+        />
         <CogIcon
           className="h-6 w-6 cursor-pointer"
           onClick={() => setIsSettingsModalOpen(true)}
@@ -441,11 +448,7 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
         isOpen={isStatsModalOpen}
         handleClose={() => {
           setIsStatsModalOpen(false)
-          setStatsInitialTab(undefined)
-          setScrollToAchievement(undefined)
         }}
-        initialTab={statsInitialTab}
-        scrollToAchievement={scrollToAchievement}
         guesses={guesses}
         gameStats={stats}
         isGameLost={isGameLost}
@@ -467,8 +470,18 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
         onToggleLettersHidden={() =>
           setResultHideLettersOverride(!effectiveHideLetters)
         }
+      />
+      <RewardsModal
+        isOpen={isRewardsModalOpen}
+        handleClose={() => {
+          setIsRewardsModalOpen(false)
+          setRewardsInitialTab(undefined)
+        }}
+        isUppercase={isUppercase}
+        excludeUrl={excludeUrl}
+        initialTab={rewardsInitialTab}
         onOpenDeadEndHelp={() => {
-          setIsStatsModalOpen(false)
+          setIsRewardsModalOpen(false)
           setInfoInitialTab('howToPlay')
           setTimeout(() => setIsInfoModalOpen(true), 300)
         }}
@@ -490,12 +503,6 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
         onToggleEnterValidationHint={() =>
           setEnterValidationHint(!enterValidationHint)
         }
-        onNavigateToAchievement={(id) => {
-          setIsSettingsModalOpen(false)
-          setStatsInitialTab('achievements')
-          setScrollToAchievement(id)
-          setTimeout(() => setIsStatsModalOpen(true), 300)
-        }}
       />
       <DonateModal
         isOpen={isDonateModalOpen}

--- a/src/components/modals/RewardsModal.tsx
+++ b/src/components/modals/RewardsModal.tsx
@@ -1,0 +1,91 @@
+import { useEffect, useState } from 'react'
+import { SparklesIcon } from '@heroicons/react/outline'
+import { useTranslation } from 'react-i18next'
+import { AchievementList } from '../achievements/AchievementList'
+import { CosmeticsPanel } from '../rewards/CosmeticsPanel'
+import { BaseModal } from './BaseModal'
+
+type RewardsTab = 'achievements' | 'cosmetics'
+
+type Props = {
+  isOpen: boolean
+  handleClose: () => void
+  isUppercase: boolean
+  excludeUrl: boolean
+  initialTab?: RewardsTab
+  scrollToAchievement?: string
+  onOpenDeadEndHelp?: () => void
+}
+
+export const RewardsModal = ({
+  isOpen,
+  handleClose,
+  isUppercase,
+  excludeUrl,
+  initialTab,
+  scrollToAchievement,
+  onOpenDeadEndHelp,
+}: Props) => {
+  const { t } = useTranslation()
+  const [activeTab, setActiveTab] = useState<RewardsTab>(
+    initialTab || 'achievements'
+  )
+  const [focusedAchievement, setFocusedAchievement] = useState<
+    string | undefined
+  >(scrollToAchievement)
+
+  useEffect(() => {
+    if (!isOpen) return
+    setActiveTab(initialTab || 'achievements')
+    setFocusedAchievement(scrollToAchievement)
+  }, [isOpen, initialTab, scrollToAchievement])
+
+  const tabs = [
+    { id: 'achievements' as const, label: t('achievements') },
+    { id: 'cosmetics' as const, label: t('cosmetics') },
+  ]
+
+  return (
+    <BaseModal
+      title={t('rewards')}
+      icon={<SparklesIcon />}
+      isOpen={isOpen}
+      handleClose={handleClose}
+    >
+      <div className="flex border-b border-gray-200 mb-4">
+        {tabs.map((tab) => (
+          <button
+            key={tab.id}
+            className={`px-4 py-2 text-sm font-medium ${
+              activeTab === tab.id
+                ? 'border-b-2 border-indigo-600 text-indigo-600 font-bold'
+                : 'text-gray-400 hover:text-gray-600'
+            }`}
+            onClick={() => setActiveTab(tab.id)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      <div className="h-[26rem]">
+        {activeTab === 'achievements' && (
+          <AchievementList
+            scrollToId={focusedAchievement}
+            onOpenDeadEndHelp={onOpenDeadEndHelp}
+          />
+        )}
+        {activeTab === 'cosmetics' && (
+          <CosmeticsPanel
+            isUppercase={isUppercase}
+            excludeUrl={excludeUrl}
+            onNavigateToAchievement={(achievementId) => {
+              setFocusedAchievement(achievementId)
+              setActiveTab('achievements')
+            }}
+          />
+        )}
+      </div>
+    </BaseModal>
+  )
+}

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -4,21 +4,6 @@ import { CogIcon } from '@heroicons/react/outline'
 import { useTranslation } from 'react-i18next'
 import { CONFIG } from '../../constants/config'
 import { localeLanguageKey } from '../../i18n'
-import { CompletedRow } from '../grid/CompletedRow'
-import { ChainBridge } from '../grid/ChainBridge'
-import { generateShareText } from '../../lib/share'
-import { getRewardMetadataLabel } from '../../lib/rewardMetadata'
-import { Temporal } from 'temporal-polyfill'
-import {
-  COSMETIC_OPTIONS,
-  CosmeticCategory,
-  equipCosmetic,
-  loadCosmeticState,
-  ALERT_MESSAGE_KEYS,
-  MSG_THEME_EMOJI,
-} from '../../lib/cosmetics'
-import { CosmeticPreview } from '../cosmetics/CosmeticPreview'
-import { loadAchievementState } from '../../lib/achievements'
 
 const langFlags: Record<string, string> = {
   en: '\uD83C\uDDFA\uD83C\uDDF8\uD83C\uDDEC\uD83C\uDDE7',
@@ -43,7 +28,6 @@ type Props = {
   onToggleHideLetters: () => void
   enterValidationHint: boolean
   onToggleEnterValidationHint: () => void
-  onNavigateToAchievement?: (achievementId: string) => void
 }
 
 const Toggle = ({
@@ -70,276 +54,6 @@ const Toggle = ({
   </button>
 )
 
-const CosmeticPicker = ({
-  category,
-  options,
-  equipped,
-  onSelect,
-  isUnlocked,
-  t,
-  labelKey,
-  onNavigateToAchievement,
-}: {
-  category: CosmeticCategory
-  options: typeof COSMETIC_OPTIONS
-  equipped: string
-  onSelect: (id: string) => void
-  isUnlocked: (option: typeof COSMETIC_OPTIONS[number]) => boolean
-  t: (key: string, opts?: any) => any
-  labelKey: string
-  onNavigateToAchievement?: (achievementId: string) => void
-}) => {
-  const [isOpen, setIsOpen] = useState(false)
-  const [msgIndex, setMsgIndex] = useState(() =>
-    Math.max(
-      0,
-      options.findIndex((o) => o.id === equipped)
-    )
-  )
-
-  const renderPreview = (optionId: string, compact = false) => (
-    <CosmeticPreview
-      category={category}
-      optionId={optionId}
-      compact={compact}
-    />
-  )
-
-  const equippedOption = options.find((o) => o.id === equipped)
-  const getOptionMetadataLabel = (option: typeof COSMETIC_OPTIONS[number]) =>
-    getRewardMetadataLabel(option.metadata)
-
-  return (
-    <>
-      <div className="flex items-center justify-between py-1.5">
-        <span className="text-sm font-medium text-gray-700">{t(labelKey)}</span>
-        <button
-          type="button"
-          className="w-36 flex items-center justify-between rounded border border-gray-300 bg-white px-2 py-1 text-sm text-gray-700"
-          onClick={() => setIsOpen(true)}
-        >
-          <span className="flex items-center justify-between w-full">
-            <span className="flex items-center">
-              {renderPreview(equipped, true)}
-            </span>
-            <span className="flex items-center gap-1">
-              <span className="truncate">
-                {equippedOption ? t(equippedOption.titleKey) : ''}
-              </span>
-              <span className="text-xs text-gray-400">{'\u25BE'}</span>
-            </span>
-          </span>
-        </button>
-      </div>
-
-      {isOpen && category !== 'endMessage' && (
-        <div
-          className="fixed inset-0 z-[60] flex items-center justify-center bg-black bg-opacity-30"
-          onClick={() => setIsOpen(false)}
-        >
-          <div
-            className="bg-white rounded-lg shadow-xl w-72 max-h-80 overflow-y-auto"
-            onClick={(e) => e.stopPropagation()}
-          >
-            <div className="px-4 py-3 border-b border-gray-200">
-              <span className="text-sm font-bold text-gray-900">
-                {t(labelKey)}
-              </span>
-            </div>
-            {options.map((option) => {
-              const unlocked = isUnlocked(option)
-              const selected = equipped === option.id
-              return (
-                <div
-                  key={option.id}
-                  className={`w-full flex items-center gap-3 px-4 py-3 text-sm text-left border-b border-gray-50 cursor-pointer ${
-                    selected
-                      ? 'bg-indigo-50 text-indigo-600'
-                      : unlocked
-                      ? 'hover:bg-gray-50 text-gray-700'
-                      : 'text-gray-300 hover:bg-gray-50'
-                  }`}
-                  onClick={() => {
-                    if (unlocked) {
-                      onSelect(option.id)
-                      setIsOpen(false)
-                    } else if (
-                      onNavigateToAchievement &&
-                      option.requiresAchievement
-                    ) {
-                      setIsOpen(false)
-                      onNavigateToAchievement(option.requiresAchievement)
-                    }
-                  }}
-                >
-                  <span className="flex-shrink-0 flex items-center">
-                    {renderPreview(option.id)}
-                  </span>
-                  <span className="flex-1 text-right min-w-0">
-                    <span className="block truncate">{t(option.titleKey)}</span>
-                    {getOptionMetadataLabel(option) && (
-                      <span className="block text-[0.625rem] leading-tight text-gray-400">
-                        {getOptionMetadataLabel(option)}
-                      </span>
-                    )}
-                  </span>
-                  <span className="w-5 text-center flex-shrink-0">
-                    {!unlocked && '\uD83D\uDD12'}
-                    {selected && unlocked && (
-                      <span className="text-indigo-600">{'\u2713'}</span>
-                    )}
-                  </span>
-                </div>
-              )
-            })}
-          </div>
-        </div>
-      )}
-
-      {isOpen &&
-        category === 'endMessage' &&
-        (() => {
-          const currentOption = options[msgIndex]
-          const unlocked = isUnlocked(currentOption)
-          const selected = equipped === currentOption.id
-          const keys = ALERT_MESSAGE_KEYS[currentOption.id]
-          const msgs = t(keys?.win || 'winMessages_classic', {
-            returnObjects: true,
-          })
-          const loss = t(keys?.loss || 'lossMessage_classic', { solution: '?' })
-
-          return (
-            <div
-              className="fixed inset-0 z-[60] flex items-center justify-center bg-black bg-opacity-30"
-              onClick={() => setIsOpen(false)}
-            >
-              <div
-                className="bg-white rounded-lg shadow-xl w-72"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <div className="px-4 py-3 border-b border-gray-200">
-                  <span className="text-sm font-bold text-gray-900">
-                    {t(labelKey)}
-                  </span>
-                </div>
-
-                <div
-                  className={`flex items-center justify-between px-4 py-3 ${
-                    selected ? 'bg-indigo-50' : ''
-                  }`}
-                >
-                  <button
-                    type="button"
-                    className="text-gray-400 hover:text-gray-600 text-lg font-bold px-2"
-                    onClick={() =>
-                      setMsgIndex(
-                        (msgIndex - 1 + options.length) % options.length
-                      )
-                    }
-                  >
-                    {'<'}
-                  </button>
-                  <span className="min-w-0 text-center">
-                    <span
-                      className={`block truncate text-sm font-semibold ${
-                        selected ? 'text-indigo-600' : 'text-gray-900'
-                      }`}
-                    >
-                      {MSG_THEME_EMOJI[currentOption.id] || ''}{' '}
-                      {t(currentOption.titleKey)}
-                    </span>
-                    {getOptionMetadataLabel(currentOption) && (
-                      <span className="block text-[0.625rem] leading-tight text-gray-400">
-                        {getOptionMetadataLabel(currentOption)}
-                      </span>
-                    )}
-                  </span>
-                  <button
-                    type="button"
-                    className="text-gray-400 hover:text-gray-600 text-lg font-bold px-2"
-                    onClick={() => setMsgIndex((msgIndex + 1) % options.length)}
-                  >
-                    {'>'}
-                  </button>
-                </div>
-
-                <div className={`px-4 pb-3 ${selected ? 'bg-indigo-50' : ''}`}>
-                  {Array.isArray(msgs) && (
-                    <table
-                      className={`w-full text-sm ${
-                        selected ? 'text-indigo-600' : 'text-gray-600'
-                      }`}
-                    >
-                      <tbody>
-                        {msgs.map((msg: string, i: number) => (
-                          <tr key={i}>
-                            <td className="text-gray-400 pr-2 py-0.5 w-6 text-right">
-                              {i + 1}.
-                            </td>
-                            <td className="py-0.5">{msg}</td>
-                          </tr>
-                        ))}
-                        <tr>
-                          <td className="text-gray-400 pr-2 py-0.5 w-6 text-right">
-                            X.
-                          </td>
-                          <td className="py-0.5">{loss}</td>
-                        </tr>
-                      </tbody>
-                    </table>
-                  )}
-                </div>
-
-                <div className={`px-4 pb-3 ${selected ? 'bg-indigo-50' : ''}`}>
-                  {!unlocked && (
-                    <button
-                      type="button"
-                      className="w-full rounded-md bg-gray-200 px-3 py-2 text-sm font-medium text-gray-400 cursor-pointer hover:bg-gray-300"
-                      onClick={() => {
-                        if (
-                          onNavigateToAchievement &&
-                          currentOption.requiresAchievement
-                        ) {
-                          setIsOpen(false)
-                          onNavigateToAchievement(
-                            currentOption.requiresAchievement
-                          )
-                        }
-                      }}
-                    >
-                      {'\uD83D\uDD12'}
-                    </button>
-                  )}
-                  {unlocked && selected && (
-                    <button
-                      type="button"
-                      disabled
-                      className="w-full rounded-md bg-indigo-100 px-3 py-2 text-sm font-medium text-indigo-600 cursor-default"
-                    >
-                      {'\u2713'}
-                    </button>
-                  )}
-                  {unlocked && !selected && (
-                    <button
-                      type="button"
-                      className="w-full rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700"
-                      onClick={() => {
-                        onSelect(currentOption.id)
-                        setIsOpen(false)
-                      }}
-                    >
-                      {t('equip')}
-                    </button>
-                  )}
-                </div>
-              </div>
-            </div>
-          )
-        })()}
-    </>
-  )
-}
-
 export const SettingsModal = ({
   isOpen,
   handleClose,
@@ -353,37 +67,9 @@ export const SettingsModal = ({
   onToggleHideLetters,
   enterValidationHint,
   onToggleEnterValidationHint,
-  onNavigateToAchievement,
 }: Props) => {
   const { t, i18n } = useTranslation()
-  const [equipped, setEquipped] = useState(() => loadCosmeticState().equipped)
   const [isLangOpen, setIsLangOpen] = useState(false)
-
-  // Sample: ocean → chain (solution = chain)
-  const sampleSolution = 'chain'
-  const sampleGuesses = [
-    ['o', 'c', 'e', 'a', 'n'],
-    ['c', 'h', 'a', 'i', 'n'],
-  ]
-
-  const achievementState = loadAchievementState()
-
-  const cosmeticCategories: {
-    category: CosmeticCategory
-    labelKey: string
-  }[] = [
-    { category: 'shareBadge', labelKey: 'shareBadgeLabel' },
-    { category: 'shareEmoji', labelKey: 'shareEmojiLabel' },
-    { category: 'cellFont', labelKey: 'cellFontLabel' },
-    { category: 'cellColor', labelKey: 'cellColorLabel' },
-    { category: 'chainStyle', labelKey: 'chainStyleLabel' },
-    { category: 'chainColor', labelKey: 'chainColorLabel' },
-    { category: 'endMessage', labelKey: 'endMessageLabel' },
-  ]
-
-  const isOptionUnlocked = (option: typeof COSMETIC_OPTIONS[number]) =>
-    !option.requiresAchievement ||
-    !!achievementState.unlocked[option.requiresAchievement]
 
   return (
     <BaseModal
@@ -469,60 +155,6 @@ export const SettingsModal = ({
           </>
         )}
 
-        {/* Sample view */}
-        <div className="my-2">
-          {/* Win message preview */}
-          {(() => {
-            const keys = ALERT_MESSAGE_KEYS[equipped.endMessage]
-            const msgs = t(keys?.win || 'winMessages_classic', {
-              returnObjects: true,
-            })
-            const msg = Array.isArray(msgs)
-              ? msgs[sampleGuesses.length - 1]
-              : ''
-            return (
-              <div className="bg-green-200 rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 overflow-hidden">
-                <div className="p-3">
-                  <p className="text-sm text-center font-medium text-gray-900">
-                    {msg}
-                  </p>
-                </div>
-              </div>
-            )
-          })()}
-
-          {/* Sample grid */}
-          <div
-            className={`flex flex-col items-center py-2 ${
-              isUppercase ? 'uppercase' : ''
-            }`}
-          >
-            <CompletedRow
-              guess={sampleGuesses[0]}
-              solution={sampleSolution}
-              chainBottomIndex={4}
-            />
-            <ChainBridge chainIndex={4} />
-            <CompletedRow
-              guess={sampleGuesses[1]}
-              solution={sampleSolution}
-              chainTopIndex={4}
-            />
-          </div>
-
-          {/* Share preview */}
-          <pre className="rounded border border-gray-200 bg-gray-50 p-2 text-xs text-gray-700 whitespace-pre leading-relaxed">
-            {generateShareText(
-              sampleGuesses,
-              false,
-              sampleSolution,
-              CONFIG.tries,
-              Temporal.Now.plainDateISO().toString(),
-              excludeUrl
-            )}
-          </pre>
-        </div>
-
         {/* Display settings */}
         <div className="flex items-center justify-between py-2">
           <span className="text-sm font-medium text-gray-700">
@@ -560,29 +192,6 @@ export const SettingsModal = ({
             onClick={onToggleEnterValidationHint}
           />
         </div>
-
-        {/* Cosmetic pickers */}
-        {cosmeticCategories.map(({ category, labelKey }) => {
-          const options = COSMETIC_OPTIONS.filter(
-            (o) => o.category === category
-          )
-          return (
-            <CosmeticPicker
-              key={category}
-              category={category}
-              options={options}
-              equipped={equipped[category]}
-              onSelect={(id) => {
-                equipCosmetic(category, id)
-                setEquipped({ ...equipped, [category]: id })
-              }}
-              isUnlocked={isOptionUnlocked}
-              t={t}
-              labelKey={labelKey}
-              onNavigateToAchievement={onNavigateToAchievement}
-            />
-          )
-        })}
       </div>
     </BaseModal>
   )

--- a/src/components/modals/StatsModal.tsx
+++ b/src/components/modals/StatsModal.tsx
@@ -3,7 +3,6 @@ import Countdown from 'react-countdown'
 import { StatBar } from '../stats/StatBar'
 import { Histogram } from '../stats/Histogram'
 import { Calendar } from '../calendar/Calendar'
-import { AchievementList } from '../achievements/AchievementList'
 import { GameStats } from '../../lib/localStorage'
 import { shareStatus, shareCustomStatus } from '../../lib/share'
 import { encodeCustomPuzzle } from '../../lib/customPuzzle'
@@ -29,9 +28,7 @@ type Props = {
   weekStartsOnMonday: boolean
   lettersHidden: boolean
   onToggleLettersHidden: () => void
-  initialTab?: 'stats' | 'calendar' | 'achievements'
-  scrollToAchievement?: string
-  onOpenDeadEndHelp?: () => void
+  initialTab?: 'stats' | 'calendar'
 }
 
 export const StatsModal = ({
@@ -51,13 +48,9 @@ export const StatsModal = ({
   lettersHidden,
   onToggleLettersHidden,
   initialTab,
-  scrollToAchievement,
-  onOpenDeadEndHelp,
 }: Props) => {
   const { t } = useTranslation()
-  const [activeTab, setActiveTab] = useState<
-    'stats' | 'calendar' | 'achievements'
-  >('stats')
+  const [activeTab, setActiveTab] = useState<'stats' | 'calendar'>('stats')
 
   useEffect(() => {
     if (isOpen) setActiveTab(initialTab || 'stats')
@@ -148,7 +141,6 @@ export const StatsModal = ({
   const tabs = [
     { id: 'stats' as const, label: t('statistics') },
     { id: 'calendar' as const, label: t('calendar') },
-    { id: 'achievements' as const, label: t('achievements') },
   ]
 
   return (
@@ -232,13 +224,6 @@ export const StatsModal = ({
             handleShare={handleCalendarShare}
             weekStartsOnMonday={weekStartsOnMonday}
             excludeUrl={excludeUrl}
-          />
-        )}
-
-        {activeTab === 'achievements' && (
-          <AchievementList
-            scrollToId={scrollToAchievement}
-            onOpenDeadEndHelp={onOpenDeadEndHelp}
           />
         )}
       </div>

--- a/src/components/pages/CreatePuzzlePage.tsx
+++ b/src/components/pages/CreatePuzzlePage.tsx
@@ -5,15 +5,17 @@ import {
   InformationCircleIcon,
   CogIcon,
   CurrencyDollarIcon,
+  SparklesIcon,
 } from '@heroicons/react/outline'
 import classnames from 'classnames'
 import { isWordInWordList } from '../../lib/words'
 import { encodeCustomPuzzle } from '../../lib/customPuzzle'
 import { loadSettings, saveSettings } from '../../lib/localStorage'
 import { Keyboard } from '../keyboard/Keyboard'
-import { InfoModal } from '../modals/InfoModal'
+import { InfoModal, InfoTab } from '../modals/InfoModal'
 import { SettingsModal } from '../modals/SettingsModal'
 import { DonateModal } from '../modals/DonateModal'
+import { RewardsModal } from '../modals/RewardsModal'
 import { CONFIG } from '../../constants/config'
 import { CREATE_MODE_LABEL, GAME_MODE_LABELS } from '../../lib/gameMode'
 
@@ -41,6 +43,8 @@ export const CreatePuzzlePage = () => {
     () => loadSettings().enterValidationHint
   )
   const [isInfoModalOpen, setIsInfoModalOpen] = useState(false)
+  const [infoInitialTab, setInfoInitialTab] = useState<InfoTab>('mode')
+  const [isRewardsModalOpen, setIsRewardsModalOpen] = useState(false)
   const [isSettingsModalOpen, setIsSettingsModalOpen] = useState(false)
   const [isDonateModalOpen, setIsDonateModalOpen] = useState(false)
 
@@ -172,7 +176,14 @@ export const CreatePuzzlePage = () => {
         </div>
         <InformationCircleIcon
           className="h-6 w-6 cursor-pointer"
-          onClick={() => setIsInfoModalOpen(true)}
+          onClick={() => {
+            setInfoInitialTab('mode')
+            setIsInfoModalOpen(true)
+          }}
+        />
+        <SparklesIcon
+          className="h-6 w-6 cursor-pointer"
+          onClick={() => setIsRewardsModalOpen(true)}
         />
         <CogIcon
           className="h-6 w-6 cursor-pointer"
@@ -284,6 +295,18 @@ export const CreatePuzzlePage = () => {
         isOpen={isInfoModalOpen}
         handleClose={() => setIsInfoModalOpen(false)}
         mode="create"
+        initialTab={infoInitialTab}
+      />
+      <RewardsModal
+        isOpen={isRewardsModalOpen}
+        handleClose={() => setIsRewardsModalOpen(false)}
+        isUppercase={isUppercase}
+        excludeUrl={excludeUrl}
+        onOpenDeadEndHelp={() => {
+          setIsRewardsModalOpen(false)
+          setInfoInitialTab('howToPlay')
+          setTimeout(() => setIsInfoModalOpen(true), 300)
+        }}
       />
       <SettingsModal
         isOpen={isSettingsModalOpen}

--- a/src/components/rewards/CosmeticsPanel.tsx
+++ b/src/components/rewards/CosmeticsPanel.tsx
@@ -1,0 +1,397 @@
+import { useState } from 'react'
+import { useTranslation } from 'react-i18next'
+import { Temporal } from 'temporal-polyfill'
+import { CONFIG } from '../../constants/config'
+import {
+  ALERT_MESSAGE_KEYS,
+  COSMETIC_OPTIONS,
+  CosmeticCategory,
+  equipCosmetic,
+  loadCosmeticState,
+  MSG_THEME_EMOJI,
+} from '../../lib/cosmetics'
+import { loadAchievementState } from '../../lib/achievements'
+import { generateShareText } from '../../lib/share'
+import { getRewardMetadataLabel } from '../../lib/rewardMetadata'
+import { ChainBridge } from '../grid/ChainBridge'
+import { CompletedRow } from '../grid/CompletedRow'
+import { CosmeticPreview } from '../cosmetics/CosmeticPreview'
+
+type CosmeticOption = typeof COSMETIC_OPTIONS[number]
+
+const cosmeticCategories: {
+  category: CosmeticCategory
+  labelKey: string
+}[] = [
+  { category: 'shareBadge', labelKey: 'shareBadgeLabel' },
+  { category: 'shareEmoji', labelKey: 'shareEmojiLabel' },
+  { category: 'cellFont', labelKey: 'cellFontLabel' },
+  { category: 'cellColor', labelKey: 'cellColorLabel' },
+  { category: 'chainStyle', labelKey: 'chainStyleLabel' },
+  { category: 'chainColor', labelKey: 'chainColorLabel' },
+  { category: 'endMessage', labelKey: 'endMessageLabel' },
+]
+
+const CosmeticPicker = ({
+  category,
+  options,
+  equipped,
+  onSelect,
+  isUnlocked,
+  labelKey,
+  onNavigateToAchievement,
+}: {
+  category: CosmeticCategory
+  options: typeof COSMETIC_OPTIONS
+  equipped: string
+  onSelect: (id: string) => void
+  isUnlocked: (option: CosmeticOption) => boolean
+  labelKey: string
+  onNavigateToAchievement?: (achievementId: string) => void
+}) => {
+  const { t } = useTranslation()
+  const [isOpen, setIsOpen] = useState(false)
+  const [msgIndex, setMsgIndex] = useState(() =>
+    Math.max(
+      0,
+      options.findIndex((o) => o.id === equipped)
+    )
+  )
+
+  const renderPreview = (optionId: string, compact = false) => (
+    <CosmeticPreview
+      category={category}
+      optionId={optionId}
+      compact={compact}
+    />
+  )
+
+  const equippedOption = options.find((o) => o.id === equipped)
+  const getOptionMetadataLabel = (option: CosmeticOption) =>
+    getRewardMetadataLabel(option.metadata)
+
+  return (
+    <>
+      <div className="flex items-center justify-between py-1.5">
+        <span className="text-sm font-medium text-gray-700">{t(labelKey)}</span>
+        <button
+          type="button"
+          className="w-36 flex items-center justify-between rounded border border-gray-300 bg-white px-2 py-1 text-sm text-gray-700"
+          onClick={() => setIsOpen(true)}
+        >
+          <span className="flex items-center justify-between w-full">
+            <span className="flex items-center">
+              {renderPreview(equipped, true)}
+            </span>
+            <span className="flex items-center gap-1">
+              <span className="truncate">
+                {equippedOption ? t(equippedOption.titleKey) : ''}
+              </span>
+              <span className="text-xs text-gray-400">{'\u25BE'}</span>
+            </span>
+          </span>
+        </button>
+      </div>
+
+      {isOpen && category !== 'endMessage' && (
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black bg-opacity-30"
+          onClick={() => setIsOpen(false)}
+        >
+          <div
+            className="bg-white rounded-lg shadow-xl w-72 max-h-80 overflow-y-auto"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="px-4 py-3 border-b border-gray-200">
+              <span className="text-sm font-bold text-gray-900">
+                {t(labelKey)}
+              </span>
+            </div>
+            {options.map((option) => {
+              const unlocked = isUnlocked(option)
+              const selected = equipped === option.id
+              return (
+                <div
+                  key={option.id}
+                  className={`w-full flex items-center gap-3 px-4 py-3 text-sm text-left border-b border-gray-50 cursor-pointer ${
+                    selected
+                      ? 'bg-indigo-50 text-indigo-600'
+                      : unlocked
+                      ? 'hover:bg-gray-50 text-gray-700'
+                      : 'text-gray-300 hover:bg-gray-50'
+                  }`}
+                  onClick={() => {
+                    if (unlocked) {
+                      onSelect(option.id)
+                      setIsOpen(false)
+                    } else if (
+                      onNavigateToAchievement &&
+                      option.requiresAchievement
+                    ) {
+                      setIsOpen(false)
+                      onNavigateToAchievement(option.requiresAchievement)
+                    }
+                  }}
+                >
+                  <span className="flex-shrink-0 flex items-center">
+                    {renderPreview(option.id)}
+                  </span>
+                  <span className="flex-1 text-right min-w-0">
+                    <span className="block truncate">{t(option.titleKey)}</span>
+                    {getOptionMetadataLabel(option) && (
+                      <span className="block text-[0.625rem] leading-tight text-gray-400">
+                        {getOptionMetadataLabel(option)}
+                      </span>
+                    )}
+                  </span>
+                  <span className="w-5 text-center flex-shrink-0">
+                    {!unlocked && '\uD83D\uDD12'}
+                    {selected && unlocked && (
+                      <span className="text-indigo-600">{'\u2713'}</span>
+                    )}
+                  </span>
+                </div>
+              )
+            })}
+          </div>
+        </div>
+      )}
+
+      {isOpen &&
+        category === 'endMessage' &&
+        (() => {
+          const currentOption = options[msgIndex]
+          const unlocked = isUnlocked(currentOption)
+          const selected = equipped === currentOption.id
+          const keys = ALERT_MESSAGE_KEYS[currentOption.id]
+          const msgs = t(keys?.win || 'winMessages_classic', {
+            returnObjects: true,
+          })
+          const loss = t(keys?.loss || 'lossMessage_classic', { solution: '?' })
+
+          return (
+            <div
+              className="fixed inset-0 z-[60] flex items-center justify-center bg-black bg-opacity-30"
+              onClick={() => setIsOpen(false)}
+            >
+              <div
+                className="bg-white rounded-lg shadow-xl w-72"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <div className="px-4 py-3 border-b border-gray-200">
+                  <span className="text-sm font-bold text-gray-900">
+                    {t(labelKey)}
+                  </span>
+                </div>
+
+                <div
+                  className={`flex items-center justify-between px-4 py-3 ${
+                    selected ? 'bg-indigo-50' : ''
+                  }`}
+                >
+                  <button
+                    type="button"
+                    className="text-gray-400 hover:text-gray-600 text-lg font-bold px-2"
+                    onClick={() =>
+                      setMsgIndex(
+                        (msgIndex - 1 + options.length) % options.length
+                      )
+                    }
+                  >
+                    {'<'}
+                  </button>
+                  <span className="min-w-0 text-center">
+                    <span
+                      className={`block truncate text-sm font-semibold ${
+                        selected ? 'text-indigo-600' : 'text-gray-900'
+                      }`}
+                    >
+                      {MSG_THEME_EMOJI[currentOption.id] || ''}{' '}
+                      {t(currentOption.titleKey)}
+                    </span>
+                    {getOptionMetadataLabel(currentOption) && (
+                      <span className="block text-[0.625rem] leading-tight text-gray-400">
+                        {getOptionMetadataLabel(currentOption)}
+                      </span>
+                    )}
+                  </span>
+                  <button
+                    type="button"
+                    className="text-gray-400 hover:text-gray-600 text-lg font-bold px-2"
+                    onClick={() => setMsgIndex((msgIndex + 1) % options.length)}
+                  >
+                    {'>'}
+                  </button>
+                </div>
+
+                <div className={`px-4 pb-3 ${selected ? 'bg-indigo-50' : ''}`}>
+                  {Array.isArray(msgs) && (
+                    <table
+                      className={`w-full text-sm ${
+                        selected ? 'text-indigo-600' : 'text-gray-600'
+                      }`}
+                    >
+                      <tbody>
+                        {msgs.map((msg: string, i: number) => (
+                          <tr key={i}>
+                            <td className="text-gray-400 pr-2 py-0.5 w-6 text-right">
+                              {i + 1}.
+                            </td>
+                            <td className="py-0.5">{msg}</td>
+                          </tr>
+                        ))}
+                        <tr>
+                          <td className="text-gray-400 pr-2 py-0.5 w-6 text-right">
+                            X.
+                          </td>
+                          <td className="py-0.5">{loss}</td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  )}
+                </div>
+
+                <div className={`px-4 pb-3 ${selected ? 'bg-indigo-50' : ''}`}>
+                  {!unlocked && (
+                    <button
+                      type="button"
+                      className="w-full rounded-md bg-gray-200 px-3 py-2 text-sm font-medium text-gray-400 cursor-pointer hover:bg-gray-300"
+                      onClick={() => {
+                        if (
+                          onNavigateToAchievement &&
+                          currentOption.requiresAchievement
+                        ) {
+                          setIsOpen(false)
+                          onNavigateToAchievement(
+                            currentOption.requiresAchievement
+                          )
+                        }
+                      }}
+                    >
+                      {'\uD83D\uDD12'}
+                    </button>
+                  )}
+                  {unlocked && selected && (
+                    <button
+                      type="button"
+                      disabled
+                      className="w-full rounded-md bg-indigo-100 px-3 py-2 text-sm font-medium text-indigo-600 cursor-default"
+                    >
+                      {'\u2713'}
+                    </button>
+                  )}
+                  {unlocked && !selected && (
+                    <button
+                      type="button"
+                      className="w-full rounded-md bg-indigo-600 px-3 py-2 text-sm font-medium text-white hover:bg-indigo-700"
+                      onClick={() => {
+                        onSelect(currentOption.id)
+                        setIsOpen(false)
+                      }}
+                    >
+                      {t('equip')}
+                    </button>
+                  )}
+                </div>
+              </div>
+            </div>
+          )
+        })()}
+    </>
+  )
+}
+
+export const CosmeticsPanel = ({
+  isUppercase,
+  excludeUrl,
+  onNavigateToAchievement,
+}: {
+  isUppercase: boolean
+  excludeUrl: boolean
+  onNavigateToAchievement?: (achievementId: string) => void
+}) => {
+  const { t } = useTranslation()
+  const [equipped, setEquipped] = useState(() => loadCosmeticState().equipped)
+  const achievementState = loadAchievementState()
+
+  const sampleSolution = 'chain'
+  const sampleGuesses = [
+    ['o', 'c', 'e', 'a', 'n'],
+    ['c', 'h', 'a', 'i', 'n'],
+  ]
+
+  const isOptionUnlocked = (option: CosmeticOption) =>
+    !option.requiresAchievement ||
+    !!achievementState.unlocked[option.requiresAchievement]
+
+  return (
+    <div className="h-full overflow-y-auto pr-1">
+      <div className="my-2">
+        {(() => {
+          const keys = ALERT_MESSAGE_KEYS[equipped.endMessage]
+          const msgs = t(keys?.win || 'winMessages_classic', {
+            returnObjects: true,
+          })
+          const msg = Array.isArray(msgs) ? msgs[sampleGuesses.length - 1] : ''
+          return (
+            <div className="bg-green-200 rounded-lg shadow-lg ring-1 ring-black ring-opacity-5 overflow-hidden">
+              <div className="p-3">
+                <p className="text-sm text-center font-medium text-gray-900">
+                  {msg}
+                </p>
+              </div>
+            </div>
+          )
+        })()}
+
+        <div
+          className={`flex flex-col items-center py-2 ${
+            isUppercase ? 'uppercase' : ''
+          }`}
+        >
+          <CompletedRow
+            guess={sampleGuesses[0]}
+            solution={sampleSolution}
+            chainBottomIndex={4}
+          />
+          <ChainBridge chainIndex={4} />
+          <CompletedRow
+            guess={sampleGuesses[1]}
+            solution={sampleSolution}
+            chainTopIndex={4}
+          />
+        </div>
+
+        <pre className="rounded border border-gray-200 bg-gray-50 p-2 text-xs text-gray-700 whitespace-pre leading-relaxed">
+          {generateShareText(
+            sampleGuesses,
+            false,
+            sampleSolution,
+            CONFIG.tries,
+            Temporal.Now.plainDateISO().toString(),
+            excludeUrl
+          )}
+        </pre>
+      </div>
+
+      {cosmeticCategories.map(({ category, labelKey }) => {
+        const options = COSMETIC_OPTIONS.filter((o) => o.category === category)
+        return (
+          <CosmeticPicker
+            key={category}
+            category={category}
+            options={options}
+            equipped={equipped[category]}
+            onSelect={(id) => {
+              equipCosmetic(category, id)
+              setEquipped({ ...equipped, [category]: id })
+            }}
+            isUnlocked={isOptionUnlocked}
+            labelKey={labelKey}
+            onNavigateToAchievement={onNavigateToAchievement}
+          />
+        )
+      })}
+    </div>
+  )
+}

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -22,6 +22,7 @@
   "deadEndRuleLink": "Dead-End-Regel",
   "guessDistribution": "Versuchsverteilung",
   "records": "Rekorde",
+  "rewards": "Belohnungen",
   "statistics": "Statistik",
   "totalTries": "Versuche gesamt",
   "successRate": "Erfolgsquote",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -22,6 +22,7 @@
   "deadEndRuleLink": "Dead End rule",
   "guessDistribution": "Guess Distribution",
   "records": "Records",
+  "rewards": "Rewards",
   "statistics": "Statistics",
   "totalTries": "Total tries",
   "successRate": "Success rate",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -19,6 +19,7 @@
   "notInWordInstructions": "La letra O no se encuentra en la palabra.",
   "guessDistribution": "Distribución de aciertos",
   "records": "Registros",
+  "rewards": "Recompensas",
   "statistics": "Estadísticas",
   "totalTries": "Jugadas",
   "successRate": "Victorias",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -22,6 +22,7 @@
   "deadEndRuleLink": "Dead End ルール",
   "guessDistribution": "推測の分布",
   "records": "記録",
+  "rewards": "報酬",
   "statistics": "統計",
   "totalTries": "総ゲーム数",
   "successRate": "成功率",

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -22,6 +22,7 @@
   "deadEndRuleLink": "Dead End 규칙",
   "guessDistribution": "추측 분포",
   "records": "기록",
+  "rewards": "보상",
   "statistics": "통계",
   "totalTries": "총 게임 수",
   "successRate": "성공률",

--- a/src/locales/sw/translation.json
+++ b/src/locales/sw/translation.json
@@ -19,6 +19,7 @@
   "notInWordInstructions": "Herufi U haiko kwa neno, pahali yoyote.",
   "guessDistribution": "Usambazaji wa kubahatisha",
   "records": "Rekodi",
+  "rewards": "Zawadi",
   "statistics": "Takwimu",
   "totalTries": "Mara ya kujaribu",
   "successRate": "Kiwango ya kushinda",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -19,6 +19,7 @@
   "notInWordInstructions": "字母 U 不在正解當中。",
   "guessDistribution": "猜詞分佈",
   "records": "記錄",
+  "rewards": "奖励",
   "statistics": "統計",
   "totalTries": "總猜測次數",
   "successRate": "成功率",


### PR DESCRIPTION
## Summary
- Add a global Rewards modal with Achievements and Cosmetics tabs.
- Move Achievements out of Records and cosmetic preview/pickers out of Settings.
- Expose Rewards from Daily, Practice, Custom, and Create headers.
- Keep locked cosmetic navigation by switching from Cosmetics to the related Achievement inside Rewards.
- Update affected E2E tests and README screenshot scripts for the new header icon order.

Closes #151
Closes #152

## Test plan
- PUBLIC_URL=/ npm run build
- npm test -- --watchAll=false
- npx playwright test e2e/achievements-cosmetics.spec.ts e2e/modals.spec.ts --project=chromium --workers=1
- npx playwright test e2e/calendar.spec.ts e2e/navigation.spec.ts e2e/share-exclude-url.spec.ts --project=chromium --workers=1

Note: npm run lint still reports pre-existing formatting issues in untouched files such as Calendar.tsx and generated word lists.