### PR TITLE
fix: show lose reason icons in records

### DIFF
--- a/src/components/events/EventRecordsPanel.tsx
+++ b/src/components/events/EventRecordsPanel.tsx
@@ -6,6 +6,7 @@ import { loadAchievementState } from '../../lib/achievements'
 import { loadAchievementProgress } from '../../lib/achievementProgress'
 import { PlayStats, getTotalGuessTimeMs } from '../../lib/playStats'
 import { shareStatus } from '../../lib/share'
+import { getLoseReasonIcon } from '../../lib/loseReasons'
 import {
   CollectedRowsByCollectible,
   getCollectibleProgressItemId,
@@ -61,10 +62,14 @@ const getResultLabel = ({
   t,
   won,
   lost,
+  endReason,
+  event,
 }: {
   t: (key: string) => string
   won: boolean
   lost: boolean
+  endReason?: string
+  event?: EventDefinition | null
 }) => {
   if (won) {
     return {
@@ -75,7 +80,7 @@ const getResultLabel = ({
   }
   if (lost) {
     return {
-      icon: '🥲',
+      icon: getLoseReasonIcon(endReason, event?.loseReasons),
       label: t('playStatsResultLose'),
       status: 'present' as const,
     }
@@ -126,6 +131,8 @@ export const EventRecordsPanel = ({
     t,
     won: todayWon,
     lost: !!todayLost && !todayWon,
+    endReason: todayResult?.endReason,
+    event,
   })
   const todayCollectedRows =
     collectible && isCurrentEvent ? collectedRows[collectible.id] ?? [] : []

--- a/src/components/modals/StatsModal.tsx
+++ b/src/components/modals/StatsModal.tsx
@@ -43,6 +43,7 @@ import { summarizeResultsAsGameStats } from '../../lib/resultStats'
 import { ShareOptionsRow } from '../stats/ShareOptionsRow'
 import { DetailStatsPanel } from '../stats/DetailStatsPanel'
 import { CONFIG } from '../../constants/config'
+import { getLoseReasonIcon } from '../../lib/loseReasons'
 import { Cell } from '../grid/Cell'
 import { CharStatus } from '../../lib/statuses'
 import {
@@ -551,7 +552,17 @@ export const StatsModal = ({
       : undefined
 
   const completedToday = isGameWon || isGameLost
-  const todayResult = isGameWon ? '😎' : isGameLost ? '🥲' : '😶‍🌫️'
+  const todayStoredResult = isEventRecords
+    ? selectedEventResults[currentDateKey]
+    : dailyResults[currentDateKey]
+  const todayResult = isGameWon
+    ? '😎'
+    : isGameLost
+    ? getLoseReasonIcon(
+        todayStoredResult?.endReason,
+        isEventRecords ? selectedEvent?.loseReasons : undefined
+      )
+    : '😶‍🌫️'
   const todayResultStatus: CharStatus = isGameWon
     ? 'correct'
     : isGameLost

--- a/src/components/stats/LoseReasonDistribution.tsx
+++ b/src/components/stats/LoseReasonDistribution.tsx
@@ -2,6 +2,7 @@ import { useTranslation } from 'react-i18next'
 import { GameStats } from '../../lib/localStorage'
 import { DailyResults } from '../../lib/dailyResults'
 import { EventLoseReasonDefinition } from '../../lib/events'
+import { DEFAULT_LOSE_REASONS } from '../../lib/loseReasons'
 
 type Props = {
   gameStats: GameStats
@@ -17,31 +18,6 @@ type LoseReasonItem = {
   value: number
   colorClass: string
 }
-
-const DEFAULT_LOSE_REASONS: EventLoseReasonDefinition[] = [
-  {
-    id: 'guess_limit',
-    icon: '❌',
-    titleKey: 'loseReasonOutOfGuesses',
-    infoKey: 'loseReasonGuessLimitInfo',
-    colorClass: 'bg-purple-500 text-purple-50',
-  },
-  {
-    id: 'dead_end',
-    icon: '🦎',
-    titleKey: 'loseReasonDeadEnd',
-    infoKey: 'loseReasonDeadEndInfo',
-    colorClass: 'bg-purple-500 text-purple-50',
-  },
-  {
-    id: 'unknown',
-    icon: '❓',
-    titleKey: 'loseReasonUnknown',
-    infoKey: 'loseReasonUnknownInfoBody',
-    colorClass: 'bg-gray-400 text-gray-50',
-    isUnknown: true,
-  },
-]
 
 export const LoseReasonDistribution = ({
   gameStats,

--- a/src/lib/loseReasons.test.ts
+++ b/src/lib/loseReasons.test.ts
@@ -1,0 +1,46 @@
+import { getLoseReasonIcon } from './loseReasons'
+
+describe('lose reason icons', () => {
+  it('uses the default Daily lose reason icons', () => {
+    expect(getLoseReasonIcon('guess_limit')).toBe('❌')
+    expect(getLoseReasonIcon('dead_end')).toBe('🦎')
+    expect(getLoseReasonIcon('unknown')).toBe('❓')
+  })
+
+  it('uses event-specific lose reason icons when provided', () => {
+    expect(
+      getLoseReasonIcon('pacman', [
+        {
+          id: 'pacman',
+          icon: '🐇',
+          titleKey: 'loseReasonPacman',
+          infoKey: 'loseReasonPacmanInfo',
+          colorClass: 'bg-purple-500 text-purple-50',
+        },
+        {
+          id: 'unknown',
+          icon: '❔',
+          titleKey: 'loseReasonUnknown',
+          infoKey: 'loseReasonUnknownInfoBody',
+          colorClass: 'bg-gray-400 text-gray-50',
+          isUnknown: true,
+        },
+      ])
+    ).toBe('🐇')
+  })
+
+  it('falls back to the event unknown icon before the default unknown icon', () => {
+    expect(
+      getLoseReasonIcon('future_reason', [
+        {
+          id: 'unknown',
+          icon: '❔',
+          titleKey: 'loseReasonUnknown',
+          infoKey: 'loseReasonUnknownInfoBody',
+          colorClass: 'bg-gray-400 text-gray-50',
+          isUnknown: true,
+        },
+      ])
+    ).toBe('❔')
+  })
+})

--- a/src/lib/loseReasons.ts
+++ b/src/lib/loseReasons.ts
@@ -1,0 +1,39 @@
+import { EventLoseReasonDefinition } from './events'
+
+export const DEFAULT_LOSE_REASONS: EventLoseReasonDefinition[] = [
+  {
+    id: 'guess_limit',
+    icon: '❌',
+    titleKey: 'loseReasonOutOfGuesses',
+    infoKey: 'loseReasonGuessLimitInfo',
+    colorClass: 'bg-purple-500 text-purple-50',
+  },
+  {
+    id: 'dead_end',
+    icon: '🦎',
+    titleKey: 'loseReasonDeadEnd',
+    infoKey: 'loseReasonDeadEndInfo',
+    colorClass: 'bg-purple-500 text-purple-50',
+  },
+  {
+    id: 'unknown',
+    icon: '❓',
+    titleKey: 'loseReasonUnknown',
+    infoKey: 'loseReasonUnknownInfoBody',
+    colorClass: 'bg-gray-400 text-gray-50',
+    isUnknown: true,
+  },
+]
+
+export const getLoseReasonIcon = (
+  endReason?: string,
+  reasonDefinitions: EventLoseReasonDefinition[] = DEFAULT_LOSE_REASONS
+): string => {
+  const reason =
+    reasonDefinitions.find((definition) => definition.id === endReason) ??
+    reasonDefinitions.find((definition) => definition.isUnknown) ??
+    reasonDefinitions.find((definition) => definition.id === 'unknown') ??
+    DEFAULT_LOSE_REASONS.find((definition) => definition.id === 'unknown')
+
+  return reason?.icon ?? '❓'
+}


### PR DESCRIPTION
## Summary
- Show the matching lose-reason icon in Records dashboard Result cells instead of a generic lose emoji.
- Reuse the same lose reason definitions for Daily and Event records, including Event-specific reasons such as the Summer Garden rabbit.
- Move default lose reason definitions into a shared helper with unit coverage.

## Test plan
- npm test -- --watchAll=false src/lib/loseReasons.test.ts src/lib/events.test.ts
- PUBLIC_URL=/ npm run build