### PR TITLE
docs: add AI assistant credits

### DIFF
--- a/src/components/modals/InfoModal.tsx
+++ b/src/components/modals/InfoModal.tsx
@@ -227,47 +227,55 @@ const HowToPlayContent = ({ focusSection }: { focusSection?: InfoSection }) => {
 
 const AboutContent = () => {
   return (
-    <p className="text-sm text-gray-500">
-      <Trans
-        i18nKey="aboutAuthorSentence"
-        values={{ language: CONFIG.language, author: CONFIG.author }}
-      >
-        This is an open source word guessing game adapted to
-        {CONFIG.language} by
-        <a href={CONFIG.authorWebsite} className="underline font-bold">
-          {CONFIG.author}
-        </a>{' '}
-      </Trans>
-      <Trans i18nKey="aboutCodeSentence">
-        Have a look at
-        <a
-          href="https://github.com/roedoejet/AnyLanguage-Word-Guessing-Game"
-          className="underline font-bold"
+    <div className="space-y-3 text-sm text-gray-500">
+      <p>
+        <Trans
+          i18nKey="aboutAuthorSentence"
+          values={{ language: CONFIG.language, author: CONFIG.author }}
         >
-          Aidan Pine's fork
-        </a>
-        and customize it for another language!
-      </Trans>
-      <Trans
-        i18nKey="aboutDataSentence"
-        values={{ wordListSource: CONFIG.wordListSource }}
-      >
-        The words for this game were sourced from
-        <a href={CONFIG.wordListSourceLink} className="underline font-bold">
-          {CONFIG.wordListSource}
-        </a>
-        .
-      </Trans>
-      <Trans i18nKey="aboutOriginalSentence">
-        You can also
-        <a
-          href="https://www.powerlanguage.co.uk/wordle/"
-          className="underline font-bold"
+          This is an open source word guessing game adapted to
+          {CONFIG.language} by
+          <a href={CONFIG.authorWebsite} className="underline font-bold">
+            {CONFIG.author}
+          </a>{' '}
+        </Trans>
+        <Trans i18nKey="aboutCodeSentence">
+          Have a look at
+          <a
+            href="https://github.com/roedoejet/AnyLanguage-Word-Guessing-Game"
+            className="underline font-bold"
+          >
+            Aidan Pine's fork
+          </a>
+          and customize it for another language!
+        </Trans>
+        <Trans
+          i18nKey="aboutDataSentence"
+          values={{ wordListSource: CONFIG.wordListSource }}
         >
-          play the original here
-        </a>
-      </Trans>
-    </p>
+          The words for this game were sourced from
+          <a href={CONFIG.wordListSourceLink} className="underline font-bold">
+            {CONFIG.wordListSource}
+          </a>
+          .
+        </Trans>
+        <Trans i18nKey="aboutOriginalSentence">
+          You can also
+          <a
+            href="https://www.powerlanguage.co.uk/wordle/"
+            className="underline font-bold"
+          >
+            play the original here
+          </a>
+        </Trans>
+      </p>
+      <p>
+        <Trans i18nKey="aboutAiCreditSentence">
+          Development was assisted by <strong>Claude Code</strong> through
+          v1.6.0 and by <strong>Codex</strong> from v1.7.0 onward.
+        </Trans>
+      </p>
+    </div>
   )
 }
 

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -333,6 +333,7 @@
   "aboutCodeSentence": "Sieh dir <1>den Originalcode</1> von <3>Hannah Park</3> an oder schau dir <5>Aidan Pines Fork</5> an und passe es für eine andere Sprache an! ",
   "aboutDataSentence": "Die Wörter für dieses Spiel stammen aus <1>{{wordListSource}}</1>. ",
   "aboutOriginalSentence": "Du kannst auch das Original <1>hier</1> spielen",
+  "aboutAiCreditSentence": "Die Entwicklung wurde bis v1.6.0 von <1>Claude Code</1> und ab v1.7.0 von <3>Codex</3> unterstützt.",
   "patchNote_updateHistory_title": "Patch Notes in der Information",
   "patchNote_updateHistory_desc": "Öffne die Information jederzeit, um die Update-Historie nach Version zu lesen.\nDas Neuigkeiten-Popup beim ersten Besuch nach einem Update bleibt erhalten.",
   "patchNote_shareBadges_title": "Teilen-Badges",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -333,6 +333,7 @@
   "aboutCodeSentence": "Check out <1>the original code</1> by <3>Hannah Park</3> or have a look at <5>Aidan Pine's fork</5> and customize it for another language! ",
   "aboutDataSentence": "The words for this game were sourced from <1>{{wordListSource}}</1>. ",
   "aboutOriginalSentence": "You can also play the original  <1>here</1>",
+  "aboutAiCreditSentence": "Development was assisted by <1>Claude Code</1> through v1.6.0 and by <3>Codex</3> from v1.7.0 onward.",
   "patchNote_updateHistory_title": "Patch Notes in Information",
   "patchNote_updateHistory_desc": "Open Information anytime to review update history by version.\nThe first-visit update popup still appears after each update.",
   "patchNote_shareBadges_title": "Share Badges",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -333,6 +333,7 @@
   "aboutCodeSentence": "Echa un vistazo al <1>código original</1> de <3>Hannah Park</3> o echa un vistazo al <5>fork de Aidan Pine</5> y personalízalo para otro idioma. ",
   "aboutDataSentence": "Las palabras para este juego se obtuvieron de <1>{{wordListSource}}</1>. ",
   "aboutOriginalSentence": "También puedes jugar la original <1>aquí</1>",
+  "aboutAiCreditSentence": "El desarrollo recibió ayuda de <1>Claude Code</1> hasta v1.6.0 y de <3>Codex</3> desde v1.7.0.",
   "patchNote_updateHistory_title": "Notas de versión en Información",
   "patchNote_updateHistory_desc": "Abre Información cuando quieras para revisar el historial por versión.\nEl popup de novedades de primera visita se mantiene tras cada actualización.",
   "patchNote_shareBadges_title": "Insignias de compartir",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -333,6 +333,7 @@
   "aboutCodeSentence": "<3>Hannah Park</3>が作成した<1>オリジナルコード</1>をチェックするか、<5>Aidan Pineのフォーク</5>を参考に他の言語を追加してみましょう！ ",
   "aboutDataSentence": "このゲームの単語は<1>{{wordListSource}}</1>から取得しています。 ",
   "aboutOriginalSentence": "オリジナルのゲームは<1>こちら</1>でプレイできます",
+  "aboutAiCreditSentence": "v1.6.0までは<1>Claude Code</1>、v1.7.0以降は<3>Codex</3>の支援を受けて開発しました。",
   "patchNote_updateHistory_title": "情報内のパッチノート",
   "patchNote_updateHistory_desc": "情報モーダルから、バージョンごとの更新履歴をいつでも確認できます。\n更新後の初回表示ポップアップもこれまで通り表示されます。",
   "patchNote_shareBadges_title": "共有バッジ",

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -326,6 +326,7 @@
   "aboutCodeSentence": "<3>Hannah Park</3>이 만든 <1>원본 코드</1>를 확인하거나, <5>Aidan Pine의 포크</5>를 참고하여 다른 언어를 추가해 보세요! ",
   "aboutDataSentence": "이 게임의 단어는 <1>{{wordListSource}}</1>에서 가져왔습니다. ",
   "aboutOriginalSentence": "원본 게임은 <1>여기</1>에서 플레이할 수 있습니다",
+  "aboutAiCreditSentence": "v1.6.0까지의 개발은 <1>Claude Code</1>의 도움을, v1.7.0부터는 <3>Codex</3>의 도움을 받았습니다.",
   "patchNote_updateHistory_title": "Information 안의 패치노트",
   "patchNote_updateHistory_desc": "Information에서 버전별 업데이트 내역을 언제든 다시 확인할 수 있습니다.\n업데이트 후 첫 방문 What's New 팝업은 기존처럼 유지됩니다.",
   "patchNote_shareBadges_title": "공유 배지",

--- a/src/locales/sw/translation.json
+++ b/src/locales/sw/translation.json
@@ -326,6 +326,7 @@
   "aboutCodeSentence": "Angalia <1>programmu</1> ya kwanza iliandikwa ni <3>Hannah Park</3> au angalia <5>mageuzi ya Aidan Pine</5> na ongeza lugha ingine! ",
   "aboutDataSentence": "Neno za mchezo huu zilitoa kutoka <1>{{wordListSource}}</1>. ",
   "aboutOriginalSentence": "Unaweza kucheza mchezo awali <1>hapa</1>",
+  "aboutAiCreditSentence": "Utengenezaji ulisaidiwa na <1>Claude Code</1> hadi v1.6.0 na <3>Codex</3> kuanzia v1.7.0.",
   "patchNote_updateHistory_title": "Vidokezo vya toleo katika Habari",
   "patchNote_updateHistory_desc": "Fungua Habari wakati wowote kuona historia ya masasisho kwa kila toleo.\nDirisha la mambo mapya la ziara ya kwanza bado litaonekana baada ya sasisho.",
   "patchNote_shareBadges_title": "Beji za kushiriki",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -326,6 +326,7 @@
   "aboutCodeSentence": "原專案作者為<3>Hannah Park</3>，原始碼在<1>the original code</1>。本遊戲的開發依據為<5>Aidan Pine's fork</5>。",
   "aboutDataSentence": "本遊戲的單詞來源為 <1>{{wordListSource}}</1>。",
   "aboutOriginalSentence": "您也可以前往 <1>here</1> 玩一玩原版的 Word-Guessing-Game 喔！",
+  "aboutAiCreditSentence": "開發過程中，v1.6.0 以前由 <1>Claude Code</1> 協助，v1.7.0 起由 <3>Codex</3> 協助。",
   "patchNote_updateHistory_title": "信息中的更新记录",
   "patchNote_updateHistory_desc": "你现在可以在信息弹窗中随时查看各版本更新记录。\n每次更新后的首次访问仍会显示 What's New 弹窗。",
   "patchNote_shareBadges_title": "分享徽章",


### PR DESCRIPTION
## Summary
- Add a small AI coding assistant credit to Information > About this game.
- Credit Claude Code for work through v1.6.0 and Codex from v1.7.0 onward.
- Add the new credit string across supported locale files.

Closes #219

## Test plan
- `node -e "for (const f of process.argv.slice(1)) JSON.parse(require('fs').readFileSync(f,'utf8')); console.log('json ok')" src/locales/*/translation.json`
- `PUBLIC_URL=/ npm run build`
