### PR TITLE
fix: keep Daily completion on session date

### DIFF
--- a/e2e/local-timezone.spec.ts
+++ b/e2e/local-timezone.spec.ts
@@ -1,6 +1,10 @@
 import { test as base, expect, Page } from '@playwright/test'
 import { PATCH_NOTES_VERSION } from '../src/constants/config'
-import { waitForGameReady, screenshot } from './fixtures/game.fixture'
+import {
+  submitWord,
+  waitForGameReady,
+  screenshot,
+} from './fixtures/game.fixture'
 
 /**
  * Tests for local timezone word reset and dailyHistory migration.
@@ -22,9 +26,7 @@ function addGameInitScript(page: Page) {
     window.addEventListener('keydown', (e) => {
       if (
         e.code === 'Backspace' &&
-        !['INPUT', 'TEXTAREA'].includes(
-          (document.activeElement?.tagName ?? '')
-        )
+        !['INPUT', 'TEXTAREA'].includes(document.activeElement?.tagName ?? '')
       ) {
         e.preventDefault()
       }
@@ -33,7 +35,9 @@ function addGameInitScript(page: Page) {
 }
 
 test.describe('Local Timezone', () => {
-  test('subtitle shows local date matching browser timezone', async ({ browser }) => {
+  test('subtitle shows local date matching browser timezone', async ({
+    browser,
+  }) => {
     // UTC 2026-03-15T22:00:00Z
     // Tokyo (UTC+9): 2026-03-16 07:00 → subtitle should show 2026-03-16
     // New York (UTC-4 EDT): 2026-03-15 18:00 → subtitle should show 2026-03-15
@@ -63,7 +67,9 @@ test.describe('Local Timezone', () => {
     await nyCtx.close()
   })
 
-  test('same local date in different timezones shows same word', async ({ browser }) => {
+  test('same local date in different timezones shows same word', async ({
+    browser,
+  }) => {
     // Both timezones see "2026-06-01" as local date, but at different UTC instants
     // Tokyo: 2026-06-01 12:00 JST = 2026-06-01T03:00:00Z
     // New York: 2026-06-01 12:00 EDT = 2026-06-01T16:00:00Z
@@ -107,7 +113,9 @@ test.describe('Local Timezone', () => {
     const tokyoTitle = await tokyoPage.title()
     await tokyoCtx.close()
 
-    const laCtx = await browser.newContext({ timezoneId: 'America/Los_Angeles' })
+    const laCtx = await browser.newContext({
+      timezoneId: 'America/Los_Angeles',
+    })
     const laPage = await laCtx.newPage()
     await addGameInitScript(laPage)
     await laPage.clock.setFixedTime(new Date('2026-04-10T23:00:00Z'))
@@ -121,10 +129,49 @@ test.describe('Local Timezone', () => {
     expect(laTitle).toContain('2026-04-10')
     expect(tokyoTitle).not.toBe(laTitle)
   })
+
+  test('Daily completion after midnight is saved to the loaded puzzle date', async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext({ timezoneId: 'Asia/Seoul' })
+    const page = await ctx.newPage()
+    await addGameInitScript(page)
+
+    // 2026-02-20 is the Daily date for HYDRO. Load just before midnight,
+    // then complete after midnight without reloading the page.
+    await page.clock.setFixedTime(new Date('2026-02-20T14:59:30Z'))
+    await page.goto('/')
+    await waitForGameReady(page)
+    await expect(page.locator('p.text-sm.text-gray-500')).toContainText(
+      '2026-02-20'
+    )
+
+    await page.clock.setFixedTime(new Date('2026-02-20T15:00:30Z'))
+    await submitWord(page, 'hydro')
+
+    await expect(page.locator('p.text-sm.text-gray-500')).toContainText(
+      '2026-02-20'
+    )
+
+    const dailyResults = await page.evaluate(() =>
+      JSON.parse(localStorage.getItem('dailyResults') || '{}')
+    )
+    expect(dailyResults['2026-02-20']).toMatchObject({
+      won: true,
+      guessCount: 1,
+      endReason: 'win',
+      solution: 'hydro',
+    })
+    expect(dailyResults['2026-02-21']).toBeUndefined()
+
+    await ctx.close()
+  })
 })
 
 test.describe('Daily History Migration', () => {
-  test('legacy integer-key dailyHistory is migrated to date-key format', async ({ browser }) => {
+  test('legacy integer-key dailyHistory is migrated to date-key format', async ({
+    browser,
+  }) => {
     const ctx = await browser.newContext({ timezoneId: 'Asia/Tokyo' })
     const page = await ctx.newPage()
     await addGameInitScript(page)
@@ -133,10 +180,13 @@ test.describe('Daily History Migration', () => {
     // epoch = 2026-02-16, so index 0 = 2026-02-16, index 1 = 2026-02-17, etc.
     // We set clock to March so these dates are in the past
     await page.addInitScript(() => {
-      const legacyHistory: Record<number, { guessCount: number; won: boolean }> = {
-        0: { guessCount: 3, won: true },   // 2026-02-16
-        1: { guessCount: 5, won: true },   // 2026-02-17
-        2: { guessCount: 6, won: false },  // 2026-02-18
+      const legacyHistory: Record<
+        number,
+        { guessCount: number; won: boolean }
+      > = {
+        0: { guessCount: 3, won: true }, // 2026-02-16
+        1: { guessCount: 5, won: true }, // 2026-02-17
+        2: { guessCount: 6, won: false }, // 2026-02-18
       }
       localStorage.setItem('dailyHistory', JSON.stringify(legacyHistory))
       localStorage.setItem('dailyHistoryStartIndex', '0')
@@ -184,9 +234,12 @@ test.describe('Daily History Migration', () => {
     // Inject legacy data for March 2026
     // epoch = 2026-02-16, index 13 = 2026-03-01, index 14 = 2026-03-02, index 15 = 2026-03-03
     await page.addInitScript(() => {
-      const legacyHistory: Record<number, { guessCount: number; won: boolean }> = {
-        13: { guessCount: 2, won: true },  // 2026-03-01
-        14: { guessCount: 4, won: true },  // 2026-03-02
+      const legacyHistory: Record<
+        number,
+        { guessCount: number; won: boolean }
+      > = {
+        13: { guessCount: 2, won: true }, // 2026-03-01
+        14: { guessCount: 4, won: true }, // 2026-03-02
         15: { guessCount: 6, won: false }, // 2026-03-03
       }
       localStorage.setItem('dailyHistory', JSON.stringify(legacyHistory))
@@ -211,7 +264,9 @@ test.describe('Daily History Migration', () => {
     await ctx.close()
   })
 
-  test('already-migrated date-key data is not re-migrated', async ({ browser }) => {
+  test('already-migrated date-key data is not re-migrated', async ({
+    browser,
+  }) => {
     const ctx = await browser.newContext()
     const page = await ctx.newPage()
     await addGameInitScript(page)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -107,6 +107,7 @@ const ALERT_TIME_MS = 2000
 type AppOwnProps = {
   mode: GameMode
   solution: string
+  dateKey?: string
   questioner?: string
   event?: EventDefinition
 }
@@ -116,13 +117,15 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
   i18n,
   mode,
   solution,
+  dateKey,
   questioner,
   event,
 }) => {
   const isDaily = mode === 'daily'
   const isCustom = mode === 'custom'
   const isEvent = mode === 'event'
-  const localDateStr = dateToKey(Temporal.Now.plainDateISO())
+  const currentDateKey = dateToKey(Temporal.Now.plainDateISO())
+  const localDateStr = isDaily ? dateKey ?? currentDateKey : currentDateKey
   const settingOverrides = isEvent ? event?.settingOverrides : undefined
   const cosmeticOverrides = useMemo(
     () =>
@@ -380,11 +383,9 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
 
   useEffect(() => {
     if (isDaily) {
-      const today = Temporal.Now.plainDateISO()
-      const todayKey = dateToKey(today)
-      initDailyHistoryStartDate(todayKey)
+      initDailyHistoryStartDate(localDateStr)
       retroUnlockAchievements(stats, loadDailyResultHistory())
-      document.title = `Wor\u{1F517}dle Daily | ${todayKey}`
+      document.title = `Wor\u{1F517}dle Daily | ${localDateStr}`
     } else if (isCustom) {
       document.title = `Wor\u{1F517}dle Custom | ${questioner}`
     } else if (isEvent) {
@@ -392,7 +393,7 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
     } else {
       document.title = `Wor\u{1F517}dle Practice`
     }
-  }, [isDaily, isCustom, isEvent, questioner, stats])
+  }, [isDaily, isCustom, isEvent, localDateStr, questioner, stats])
 
   useEffect(() => {
     if (!isEvent || !event || isPatchNotesModalOpen) return

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -9,14 +9,20 @@ import {
 } from 'react-router-dom'
 import './index.css'
 import App from './App'
-import { solution as dailySolution, isWordInWordList } from './lib/words'
+import {
+  solution as dailySolution,
+  dateKey as dailyDateKey,
+  isWordInWordList,
+} from './lib/words'
 import { getRandomWord } from './lib/words'
 import { decodeCustomPuzzle } from './lib/customPuzzle'
 import { getActiveEvent, getEventWordOfDay } from './lib/events'
 import { CreatePuzzlePage } from './components/pages/CreatePuzzlePage'
 import reportWebVitals from './reportWebVitals'
 
-const DailyPage = () => <App mode="daily" solution={dailySolution} />
+const DailyPage = () => (
+  <App mode="daily" solution={dailySolution} dateKey={dailyDateKey} />
+)
 
 const PracticePage = () => {
   const [practiceSolution] = useState(() => getRandomWord())

--- a/src/lib/words.ts
+++ b/src/lib/words.ts
@@ -18,18 +18,18 @@ export const getRandomWord = () => {
 export const getWordOfDay = () => {
   const epoch = Temporal.PlainDate.from(CONFIG.startDate)
   const today = Temporal.Now.plainDateISO()
+  const dateKey = today.toString()
   const index = today.since(epoch).days
 
   const tz = Temporal.Now.timeZoneId()
-  const tomorrow = today
-    .add({ days: 1 })
-    .toZonedDateTime(tz).epochMilliseconds
+  const tomorrow = today.add({ days: 1 }).toZonedDateTime(tz).epochMilliseconds
 
   return {
     solution: WORDS[index % WORDS.length],
     solutionIndex: index,
+    dateKey,
     tomorrow,
   }
 }
 
-export const { solution, solutionIndex, tomorrow } = getWordOfDay()
+export const { solution, solutionIndex, dateKey, tomorrow } = getWordOfDay()


### PR DESCRIPTION
## Summary
- Freeze the Daily puzzle date key at page load and pass it into the game session.
- Use the loaded Daily date for result saving, detail stats, subtitle/title, and achievement context even if local midnight passes before completion.
- Add a timezone E2E regression test that opens the 2026-02-20 Daily before midnight and solves it after midnight.

Closes #222

## Test plan
- `npm test -- --watchAll=false --runTestsByPath src/App.test.tsx`
- `PUBLIC_URL=/ npm run build`
- `npx playwright test e2e/local-timezone.spec.ts --project=chromium --grep "Daily completion after midnight" --workers=1 --reporter=list`
