### PR TITLE
feat: add hidden dark mode infrastructure

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -170,6 +170,7 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
   const [isUppercase, setIsUppercase] = useState(
     () => loadSettings().isUppercase
   )
+  const [isDarkMode, setIsDarkMode] = useState(() => loadSettings().isDarkMode)
   const [weekStartsOnMonday, setWeekStartsOnMonday] = useState(
     () => loadSettings().weekStartsOnMonday
   )
@@ -436,11 +437,22 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
   useEffect(() => {
     saveSettings({
       isUppercase,
+      isDarkMode,
       weekStartsOnMonday,
       excludeUrl,
       enterValidationHint,
     })
-  }, [isUppercase, weekStartsOnMonday, excludeUrl, enterValidationHint])
+  }, [
+    isUppercase,
+    isDarkMode,
+    weekStartsOnMonday,
+    excludeUrl,
+    enterValidationHint,
+  ])
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('theme-dark', isDarkMode)
+  }, [isDarkMode])
 
   useEffect(() => {
     if (!isGameWon && !isGameLost) {
@@ -1121,6 +1133,8 @@ const App: React.FC<WithTranslation & AppOwnProps> = ({
         handleClose={() => setIsSettingsModalOpen(false)}
         isUppercase={isUppercase}
         onToggleUppercase={() => setIsUppercase(!isUppercase)}
+        isDarkMode={isDarkMode}
+        onToggleDarkMode={() => setIsDarkMode(!isDarkMode)}
         weekStartsOnMonday={weekStartsOnMonday}
         onToggleWeekStartsOnMonday={() =>
           setWeekStartsOnMonday(!weekStartsOnMonday)

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -224,12 +224,17 @@ export const SettingsModal = ({
           >
             <Toggle checked={isUppercase} onClick={onToggleUppercase} />
           </SettingRow>
-          <SettingRow
-            label={t('darkModeLabel')}
-            description={t('darkModeDescription')}
-          >
-            <Toggle checked={isDarkMode} onClick={onToggleDarkMode} />
-          </SettingRow>
+          {/*
+            Dark mode support is implemented, but the Settings entry stays
+            hidden in v1.7.0 so the later horror Event theme can introduce it
+            with stronger impact. Re-enable this row when the theme is ready.
+            <SettingRow
+              label={t('darkModeLabel')}
+              description={t('darkModeDescription')}
+            >
+              <Toggle checked={isDarkMode} onClick={onToggleDarkMode} />
+            </SettingRow>
+          */}
           <SettingRow
             label={t('excludeUrlLabel')}
             description={t('excludeUrlDescription')}

--- a/src/components/modals/SettingsModal.tsx
+++ b/src/components/modals/SettingsModal.tsx
@@ -21,6 +21,8 @@ type Props = {
   handleClose: () => void
   isUppercase: boolean
   onToggleUppercase: () => void
+  isDarkMode: boolean
+  onToggleDarkMode: () => void
   weekStartsOnMonday: boolean
   onToggleWeekStartsOnMonday: () => void
   excludeUrl: boolean
@@ -108,6 +110,8 @@ export const SettingsModal = ({
   handleClose,
   isUppercase,
   onToggleUppercase,
+  isDarkMode,
+  onToggleDarkMode,
   weekStartsOnMonday,
   onToggleWeekStartsOnMonday,
   excludeUrl,
@@ -219,6 +223,12 @@ export const SettingsModal = ({
             description={t('uppercaseDescription')}
           >
             <Toggle checked={isUppercase} onClick={onToggleUppercase} />
+          </SettingRow>
+          <SettingRow
+            label={t('darkModeLabel')}
+            description={t('darkModeDescription')}
+          >
+            <Toggle checked={isDarkMode} onClick={onToggleDarkMode} />
           </SettingRow>
           <SettingRow
             label={t('excludeUrlLabel')}

--- a/src/components/pages/CreatePuzzlePage.tsx
+++ b/src/components/pages/CreatePuzzlePage.tsx
@@ -32,6 +32,7 @@ export const CreatePuzzlePage = () => {
   const [isUppercase, setIsUppercase] = useState(
     () => loadSettings().isUppercase
   )
+  const [isDarkMode, setIsDarkMode] = useState(() => loadSettings().isDarkMode)
   const [weekStartsOnMonday, setWeekStartsOnMonday] = useState(
     () => loadSettings().weekStartsOnMonday
   )
@@ -51,11 +52,22 @@ export const CreatePuzzlePage = () => {
   useEffect(() => {
     saveSettings({
       isUppercase,
+      isDarkMode,
       weekStartsOnMonday,
       excludeUrl,
       enterValidationHint,
     })
-  }, [isUppercase, weekStartsOnMonday, excludeUrl, enterValidationHint])
+  }, [
+    isUppercase,
+    isDarkMode,
+    weekStartsOnMonday,
+    excludeUrl,
+    enterValidationHint,
+  ])
+
+  useEffect(() => {
+    document.documentElement.classList.toggle('theme-dark', isDarkMode)
+  }, [isDarkMode])
 
   const fallbackCopy = (text: string) => {
     const textarea = document.createElement('textarea')
@@ -326,6 +338,8 @@ export const CreatePuzzlePage = () => {
         handleClose={() => setIsSettingsModalOpen(false)}
         isUppercase={isUppercase}
         onToggleUppercase={() => setIsUppercase(!isUppercase)}
+        isDarkMode={isDarkMode}
+        onToggleDarkMode={() => setIsDarkMode(!isDarkMode)}
         weekStartsOnMonday={weekStartsOnMonday}
         onToggleWeekStartsOnMonday={() =>
           setWeekStartsOnMonday(!weekStartsOnMonday)

--- a/src/index.css
+++ b/src/index.css
@@ -9,6 +9,78 @@ div {
   font-family: 'BCSans', 'Noto Sans', sans-serif;
 }
 
+html.theme-dark,
+html.theme-dark body {
+  background: #0f172a;
+  color: #e5e7eb;
+  color-scheme: dark;
+}
+
+html.theme-dark .bg-white {
+  background-color: #111827 !important;
+}
+
+html.theme-dark [role='switch'] .bg-white {
+  background-color: #ffffff !important;
+}
+
+html.theme-dark .bg-gray-50,
+html.theme-dark .bg-gray-100,
+html.theme-dark .bg-slate-100 {
+  background-color: #1f2937 !important;
+}
+
+html.theme-dark .bg-gray-200,
+html.theme-dark .bg-slate-200 {
+  background-color: #374151 !important;
+}
+
+html.theme-dark .bg-gray-300 {
+  background-color: #4b5563 !important;
+}
+
+html.theme-dark .border-gray-50,
+html.theme-dark .border-gray-100,
+html.theme-dark .border-gray-200,
+html.theme-dark .border-gray-300,
+html.theme-dark .border-slate-200,
+html.theme-dark .border-gray-400 {
+  border-color: #374151 !important;
+}
+
+html.theme-dark .border-black {
+  border-color: #d1d5db !important;
+}
+
+html.theme-dark .text-black,
+html.theme-dark .text-gray-900,
+html.theme-dark .text-gray-800 {
+  color: #f9fafb !important;
+}
+
+html.theme-dark .text-gray-700,
+html.theme-dark .text-gray-600 {
+  color: #d1d5db !important;
+}
+
+html.theme-dark .text-gray-500,
+html.theme-dark .text-gray-400 {
+  color: #9ca3af !important;
+}
+
+html.theme-dark input,
+html.theme-dark textarea,
+html.theme-dark select {
+  background-color: #111827;
+  color: #f9fafb;
+  border-color: #374151;
+}
+
+html.theme-dark input::placeholder,
+html.theme-dark textarea::placeholder {
+  color: #6b7280;
+}
+
 .cell-animation {
   animation: revealCharCell linear;
   animation-duration: 0.15s;

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -65,6 +65,7 @@ const settingsKey = 'settings'
 
 export type Settings = {
   isUppercase: boolean
+  isDarkMode: boolean
   weekStartsOnMonday: boolean
   excludeUrl: boolean
   enterValidationHint: boolean
@@ -78,6 +79,7 @@ export const loadSettings = (): Settings => {
   const settings = localStorage.getItem(settingsKey)
   const defaults = {
     isUppercase: false,
+    isDarkMode: false,
     weekStartsOnMonday: false,
     excludeUrl: false,
     enterValidationHint: false,

--- a/src/locales/de/translation.json
+++ b/src/locales/de/translation.json
@@ -195,6 +195,8 @@
   "gameplaySettingsGroup": "Gameplay",
   "uppercaseLabel": "In Großbuchstaben anzeigen",
   "uppercaseDescription": "Zeigt Buchstaben auf dem Spielbrett und der Tastatur in Großbuchstaben an.",
+  "darkModeLabel": "Dunkelmodus",
+  "darkModeDescription": "Verwende eine dunklere Oberfläche für Spiel, Rekorde, Belohnungen und Einstellungen.",
   "weekStartLabel": "Woche am Montag beginnen",
   "weekStartDescription": "Verwendet Montag als ersten Tag im Kalender.",
   "excludeUrlLabel": "URL beim Teilen ausschließen",

--- a/src/locales/en/translation.json
+++ b/src/locales/en/translation.json
@@ -195,6 +195,8 @@
   "gameplaySettingsGroup": "Gameplay",
   "uppercaseLabel": "Display in Uppercase",
   "uppercaseDescription": "Show board letters and keyboard labels in uppercase.",
+  "darkModeLabel": "Dark Mode",
+  "darkModeDescription": "Use a darker interface for the game, records, rewards, and settings.",
   "weekStartLabel": "Start Week on Monday",
   "weekStartDescription": "Use Monday as the first day in the calendar.",
   "excludeUrlLabel": "Exclude URL when Sharing",

--- a/src/locales/es/translation.json
+++ b/src/locales/es/translation.json
@@ -195,6 +195,8 @@
   "gameplaySettingsGroup": "Jugabilidad",
   "uppercaseLabel": "Mostrar en mayúsculas",
   "uppercaseDescription": "Muestra las letras del tablero y del teclado en mayúsculas.",
+  "darkModeLabel": "Modo oscuro",
+  "darkModeDescription": "Usa una interfaz más oscura para el juego, los récords, las recompensas y los ajustes.",
   "weekStartLabel": "Empezar semana el lunes",
   "weekStartDescription": "Usa el lunes como primer día en el calendario.",
   "excludeUrlLabel": "Excluir URL al compartir",

--- a/src/locales/ja/translation.json
+++ b/src/locales/ja/translation.json
@@ -195,6 +195,8 @@
   "gameplaySettingsGroup": "ゲームプレイ",
   "uppercaseLabel": "大文字で表示",
   "uppercaseDescription": "盤面の文字とキーボードの表示を大文字にします。",
+  "darkModeLabel": "ダークモード",
+  "darkModeDescription": "ゲーム、記録、リワード、設定を暗いインターフェースで表示します。",
   "weekStartLabel": "週の始まりを月曜日に",
   "weekStartDescription": "カレンダーで週の始まりを月曜日にします。",
   "excludeUrlLabel": "共有時にURLを除外",

--- a/src/locales/ko/translation.json
+++ b/src/locales/ko/translation.json
@@ -195,6 +195,8 @@
   "gameplaySettingsGroup": "게임플레이",
   "uppercaseLabel": "대문자로 표시",
   "uppercaseDescription": "보드 글자와 키보드 라벨을 대문자로 표시합니다.",
+  "darkModeLabel": "다크 모드",
+  "darkModeDescription": "게임, 기록, 리워드, 설정 화면을 어두운 인터페이스로 표시합니다.",
   "weekStartLabel": "달력 주 시작을 월요일로",
   "weekStartDescription": "달력에서 한 주의 시작을 월요일로 표시합니다.",
   "excludeUrlLabel": "공유 시 URL 제외",

--- a/src/locales/sw/translation.json
+++ b/src/locales/sw/translation.json
@@ -195,6 +195,8 @@
   "gameplaySettingsGroup": "Uchezaji",
   "uppercaseLabel": "Onyesha kwa herufi kubwa",
   "uppercaseDescription": "Onyesha herufi za ubao na kibodi kwa herufi kubwa.",
+  "darkModeLabel": "Hali ya giza",
+  "darkModeDescription": "Tumia muonekano wa giza kwa mchezo, rekodi, zawadi na mipangilio.",
   "weekStartLabel": "Anza wiki siku ya Jumatatu",
   "weekStartDescription": "Tumia Jumatatu kama siku ya kwanza kwenye kalenda.",
   "excludeUrlLabel": "Ondoa URL wakati wa kushiriki",

--- a/src/locales/zh/translation.json
+++ b/src/locales/zh/translation.json
@@ -195,6 +195,8 @@
   "gameplaySettingsGroup": "玩法",
   "uppercaseLabel": "以大写显示",
   "uppercaseDescription": "以大写显示棋盘字母和键盘标签。",
+  "darkModeLabel": "深色模式",
+  "darkModeDescription": "为游戏、记录、奖励和设置使用较暗的界面。",
   "weekStartLabel": "以周一作为每周起始日",
   "weekStartDescription": "在日历中将周一作为一周的第一天。",
   "excludeUrlLabel": "分享时排除URL",


### PR DESCRIPTION
## Summary
- Add persisted dark mode settings plumbing and apply a global `theme-dark` class from Daily and Create flows.
- Add dark-theme CSS coverage for common app surfaces, modals, inputs, borders, and text utilities.
- Add dark mode locale strings for all supported languages.
- Keep the Settings row commented out for `v1.7.0` so a later horror Event theme can introduce the feature with stronger impact.

Closes #172

## Test plan
- `npm test -- --watchAll=false --runTestsByPath src/App.test.tsx src/components/grid/Grid.test.tsx src/components/keyboard/Keyboard.test.tsx`
- `npm test -- --watchAll=false --runTestsByPath src/App.test.tsx`
- `PUBLIC_URL=/ npm run build`
- Manual production smoke before hiding the row confirmed dark-theme application and localStorage persistence.